### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,6 @@ jobs:
           go-version-file: go.mod
 
       - uses: golangci/golangci-lint-action@v6
+        with:
+          install-mode: goinstall
+          version: v1.64.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...
+
+      - run: go vet ./...
+
+      - run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@v6

--- a/internal/server/healthz.go
+++ b/internal/server/healthz.go
@@ -7,5 +7,5 @@ import (
 func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"status":"healthy"}`))
+	_, _ = w.Write([]byte(`{"status":"healthy"}`))
 }


### PR DESCRIPTION
## What

Add a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on push/PR to `main`: `go build`, `go vet`, `go test`, and `golangci-lint` as a separate job.

## Why

Build/test/lint checks were only run manually so far (per the PR template's QA section, which now intentionally leaves this to CI). This wires that up so PRs get automatic feedback.

## QA

## Ref

Fixes one pre-existing `errcheck` finding in `healthzHandler` (unchecked `w.Write`) that the new lint job surfaced.