### PR TITLE
Seed metrics with 0 for never-run jobs, delete metrics for removed jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/internal/collector/active_runs.go
+++ b/internal/collector/active_runs.go
@@ -54,6 +54,20 @@ func CollectActiveRuns(ctx context.Context, c *DagsterCollector) {
 	}
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
+
+	for jobKey := range c.knownJobs {
+		for _, status := range activeStatuses {
+			key := ActiveRunKey{
+				JobName:      jobKey.JobName,
+				LocationName: jobKey.LocationName,
+				Status:       status,
+			}
+			if _, ok := counts[key]; !ok {
+				counts[key] = 0
+			}
+		}
+	}
+
 	c.activeRunsCounts = counts
 }
 

--- a/internal/collector/active_runs_test.go
+++ b/internal/collector/active_runs_test.go
@@ -44,3 +44,33 @@ func TestCollectActiveRunsLocationLabel(t *testing.T) {
 	assert.Equal(t, 1, c.activeRunsCounts[ActiveRunKey{JobName: "job_a", LocationName: "loc_a", Status: "STARTED"}])
 	assert.Equal(t, 1, c.activeRunsCounts[ActiveRunKey{JobName: "job_b", LocationName: unknownLocationName, Status: "QUEUED"}])
 }
+
+func TestCollectActiveRunsZeroFillsKnownJobs(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+			"data": {
+				"runsOrError": {
+					"__typename": "Runs",
+					"results": []
+				}
+			}
+		}`))
+		if err != nil {
+			t.Fatalf("failed to write mock response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	c.knownJobs = map[JobKey]struct{}{
+		{JobName: "never_run_job", LocationName: "loc_a"}: {},
+	}
+
+	CollectActiveRuns(t.Context(), c)
+
+	for _, status := range activeStatuses {
+		assert.Equal(t, 0, c.activeRunsCounts[ActiveRunKey{JobName: "never_run_job", LocationName: "loc_a", Status: status}])
+	}
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -21,7 +21,7 @@ type DagsterCollector struct {
 	activeRunsCounts map[ActiveRunKey]int
 	processedRuns    *ttlcache.Cache[string, struct{}]
 	lookbackWindow   time.Duration
-	jobLocations     map[string]string
+	knownJobs        map[JobKey]struct{}
 }
 
 func newDagsterCache(ctx context.Context, cacheTTL time.Duration) *ttlcache.Cache[string, struct{}] {

--- a/internal/collector/completed_runs.go
+++ b/internal/collector/completed_runs.go
@@ -56,3 +56,28 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) {
 		c.completedRunsCounter.WithLabelValues(result.JobName, location, strings.ToLower(result.Status)).Inc()
 	}
 }
+
+// seedCompletedRunsCounter ensures every known job has a 0-valued series for
+// each completed status, so jobs that have never run show 0 instead of no data.
+// Callers must hold c.mutex.
+func seedCompletedRunsCounter(c *DagsterCollector, known map[JobKey]struct{}) {
+	for key := range known {
+		for _, status := range completedStatuses {
+			c.completedRunsCounter.WithLabelValues(key.JobName, key.LocationName, strings.ToLower(status)).Add(0)
+		}
+	}
+}
+
+// pruneCompletedRunsCounter deletes series for jobs that existed in previous
+// but no longer exist in known, so metrics for removed jobs stop being reported.
+// Callers must hold c.mutex.
+func pruneCompletedRunsCounter(c *DagsterCollector, previous, known map[JobKey]struct{}) {
+	for key := range previous {
+		if _, ok := known[key]; ok {
+			continue
+		}
+		for _, status := range completedStatuses {
+			c.completedRunsCounter.DeleteLabelValues(key.JobName, key.LocationName, strings.ToLower(status))
+		}
+	}
+}

--- a/internal/collector/completed_runs_test.go
+++ b/internal/collector/completed_runs_test.go
@@ -1,0 +1,102 @@
+package collector
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedCompletedRunsCounter(t *testing.T) {
+	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour)
+
+	known := map[JobKey]struct{}{
+		{JobName: "job_a", LocationName: "loc_a"}: {},
+	}
+
+	seedCompletedRunsCounter(c, known)
+
+	for _, status := range completedStatuses {
+		metric, err := c.completedRunsCounter.GetMetricWithLabelValues("job_a", "loc_a", strings.ToLower(status))
+		require.NoError(t, err)
+		assert.Equal(t, float64(0), testutil.ToFloat64(metric))
+	}
+}
+
+func TestPruneCompletedRunsCounter(t *testing.T) {
+	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour)
+
+	previous := map[JobKey]struct{}{
+		{JobName: "gone_job", LocationName: "loc_a"}: {},
+	}
+	known := map[JobKey]struct{}{}
+
+	seedCompletedRunsCounter(c, previous)
+	pruneCompletedRunsCounter(c, previous, known)
+
+	ch := make(chan prometheus.Metric, 8)
+	go func() {
+		c.completedRunsCounter.Collect(ch)
+		close(ch)
+	}()
+
+	count := 0
+	for range ch {
+		count++
+	}
+	assert.Equal(t, 0, count, "expected no series to remain for a pruned job")
+}
+
+func TestCollectJobLocationsSeedsAndPrunes(t *testing.T) {
+	call := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		body := `{
+			"data": {
+				"repositoriesOrError": {
+					"__typename": "RepositoryConnection",
+					"nodes": [
+						{"name": "repo", "location": {"name": "loc_a"}, "jobs": [{"name": "job_a"}]}
+					]
+				}
+			}
+		}`
+		if call > 1 {
+			body = `{
+				"data": {
+					"repositoriesOrError": {
+						"__typename": "RepositoryConnection",
+						"nodes": []
+					}
+				}
+			}`
+		}
+
+		_, err := w.Write([]byte(body))
+		if err != nil {
+			t.Fatalf("failed to write mock response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+
+	CollectJobLocations(t.Context(), c)
+	assert.Contains(t, c.knownJobs, JobKey{JobName: "job_a", LocationName: "loc_a"})
+
+	metric, err := c.completedRunsCounter.GetMetricWithLabelValues("job_a", "loc_a", "success")
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), testutil.ToFloat64(metric))
+
+	CollectJobLocations(t.Context(), c)
+	assert.NotContains(t, c.knownJobs, JobKey{JobName: "job_a", LocationName: "loc_a"})
+}

--- a/internal/collector/job_locations.go
+++ b/internal/collector/job_locations.go
@@ -5,6 +5,11 @@ import (
 	"log"
 )
 
+type JobKey struct {
+	JobName      string
+	LocationName string
+}
+
 func CollectJobLocations(ctx context.Context, c *DagsterCollector) {
 	req := getJobLocationsRequest()
 
@@ -14,14 +19,19 @@ func CollectJobLocations(ctx context.Context, c *DagsterCollector) {
 		return
 	}
 
-	locations := make(map[string]string)
+	known := make(map[JobKey]struct{})
 	for _, repo := range resp.Data.RepositoriesOrError.Nodes {
 		for _, job := range repo.Jobs {
-			locations[job.Name] = repo.Location.Name
+			known[JobKey{JobName: job.Name, LocationName: repo.Location.Name}] = struct{}{}
 		}
 	}
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	c.jobLocations = locations
+
+	previous := c.knownJobs
+	c.knownJobs = known
+
+	pruneCompletedRunsCounter(c, previous, known)
+	seedCompletedRunsCounter(c, known)
 }

--- a/internal/collector/queries/get_jobs_per_repository.graphql
+++ b/internal/collector/queries/get_jobs_per_repository.graphql
@@ -12,5 +12,9 @@ query GetJobsPerLocation {
         }
       }
     }
+    ... on PythonError {
+      message
+      stack
+    }
   }
 }

--- a/internal/server/scrape.go
+++ b/internal/server/scrape.go
@@ -8,6 +8,7 @@ import (
 )
 
 func scrapeDagster(ctx context.Context, c *collector.DagsterCollector) {
+	collector.CollectJobLocations(ctx, c)
 	collector.CollectActiveRuns(ctx, c)
 	collector.CollectCompletedRuns(ctx, c)
 }


### PR DESCRIPTION
## What

Implement the remaining two `todo.yml` items:
1. Jobs that have never run show `0` instead of no data.
2. Metrics for jobs that no longer exist get deleted.

## Why

`dagster_active_runs` and `dagster_completed_runs_total` only ever had series for jobs that actually produced a run, so dashboards/alerts for idle or newly-added jobs showed "no data" instead of `0`, and `dagster_completed_runs_total` (a persistent CounterVec) kept stale series around forever for jobs that were deleted or renamed in Dagster.

`CollectJobLocations` (previously unwired, left over from the location-label PR) is now called first in the scrape loop and used as the live "roster" of known `(job_name, location)` pairs:
- `CollectActiveRuns` seeds a `0` count for every known job x active status with no matching run.
- `seedCompletedRunsCounter` creates a `0`-valued series for every known job; `pruneCompletedRunsCounter` deletes series for jobs that dropped out of the roster since the previous scrape.

Job identity is now `JobKey{JobName, LocationName}` (a set), not `map[string]string`, so two locations with same-named jobs don't collide.

## QA

## Ref

Follow-up from #1 / #2. `todo.yml` is intentionally not included in this PR.