### PR TITLE
Add dagster_last_run_info metric for latest run status

### DIFF
--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -124,6 +124,74 @@
         "x": 0,
         "y": 13
       }
+    },
+    {
+      "title": "Latest Run Status",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "dagster_last_run_info",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "success": {
+                        "text": "Success",
+                        "color": "green"
+                      },
+                      "failure": {
+                        "text": "Failure",
+                        "color": "red"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      }
     }
   ],
   "templating": {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -16,12 +16,14 @@ type DagsterCollector struct {
 
 	activeRunsDesc       *prometheus.Desc
 	completedRunsCounter *prometheus.CounterVec
+	lastRunStatusDesc    *prometheus.Desc
 
 	mutex            sync.Mutex
 	activeRunsCounts map[ActiveRunKey]int
 	processedRuns    *ttlcache.Cache[string, struct{}]
 	lookbackWindow   time.Duration
 	knownJobs        map[JobKey]struct{}
+	lastRunStatus    map[JobKey]string
 }
 
 func newDagsterCache(ctx context.Context, cacheTTL time.Duration) *ttlcache.Cache[string, struct{}] {
@@ -56,6 +58,12 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			},
 			[]string{"job_name", "location", "status"},
 		),
+		lastRunStatusDesc: prometheus.NewDesc(
+			"dagster_last_run_info",
+			"Status of the most recently completed run for a job within the lookback window (value is always 1; status is carried in the status label)",
+			[]string{"job_name", "location", "status"},
+			nil,
+		),
 		processedRuns:  cache,
 		lookbackWindow: lookbackWindow,
 	}
@@ -63,10 +71,12 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 
 func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.activeRunsDesc
+	ch <- c.lastRunStatusDesc
 	c.completedRunsCounter.Describe(ch)
 }
 
 func (c *DagsterCollector) Collect(ch chan<- prometheus.Metric) {
 	reflectActiveRuns(c, ch)
+	reflectLastRunStatus(c, ch)
 	c.completedRunsCounter.Collect(ch)
 }

--- a/internal/collector/completed_runs.go
+++ b/internal/collector/completed_runs.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	ttlcache "github.com/jellydator/ttlcache/v3"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -38,22 +39,54 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) {
 		log.Printf("failed to collect active runs from dagster: %v", err)
 		return
 	}
+	type latestRun struct {
+		status  string
+		endTime float64
+	}
+	latest := make(map[JobKey]latestRun)
+
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	for _, result := range resp.Data.RunsOrError.Results {
+		location := unknownLocationName
+		if result.RepositoryOrigin != nil {
+			location = result.RepositoryOrigin.RepositoryLocationName
+		}
+
+		key := JobKey{JobName: result.JobName, LocationName: location}
+		if current, ok := latest[key]; !ok || result.EndTime > current.endTime {
+			latest[key] = latestRun{status: result.Status, endTime: result.EndTime}
+		}
+
 		if item := c.processedRuns.Get(result.RunId); item != nil {
 			continue
 		}
 
 		c.processedRuns.Set(result.RunId, struct{}{}, ttlcache.DefaultTTL)
 
-		location := unknownLocationName
-		if result.RepositoryOrigin != nil {
-			location = result.RepositoryOrigin.RepositoryLocationName
-		}
-
 		c.completedRunsCounter.WithLabelValues(result.JobName, location, strings.ToLower(result.Status)).Inc()
+	}
+
+	lastRunStatus := make(map[JobKey]string, len(latest))
+	for key, run := range latest {
+		lastRunStatus[key] = run.status
+	}
+	c.lastRunStatus = lastRunStatus
+}
+
+func reflectLastRunStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	for key, status := range c.lastRunStatus {
+		ch <- prometheus.MustNewConstMetric(
+			c.lastRunStatusDesc,
+			prometheus.GaugeValue,
+			1,
+			key.JobName,
+			key.LocationName,
+			strings.ToLower(status),
+		)
 	}
 }
 

--- a/internal/collector/completed_runs_test.go
+++ b/internal/collector/completed_runs_test.go
@@ -9,9 +9,59 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCollectCompletedRunsTracksLastRunStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+			"data": {
+				"runsOrError": {
+					"__typename": "Runs",
+					"results": [
+						{"runId": "run_1", "jobName": "job_a", "status": "FAILURE", "endTime": 100, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "loc_a"}},
+						{"runId": "run_2", "jobName": "job_a", "status": "SUCCESS", "endTime": 200, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "loc_a"}}
+					]
+				}
+			}
+		}`))
+		if err != nil {
+			t.Fatalf("failed to write mock response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	CollectCompletedRuns(t.Context(), c)
+
+	assert.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}])
+
+	ch := make(chan prometheus.Metric, 8)
+	go func() {
+		reflectLastRunStatus(c, ch)
+		close(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	require.Len(t, metrics, 1)
+
+	var m dto.Metric
+	require.NoError(t, metrics[0].Write(&m))
+	assert.Equal(t, float64(1), m.GetGauge().GetValue())
+
+	labels := make(map[string]string)
+	for _, l := range m.GetLabel() {
+		labels[l.GetName()] = l.GetValue()
+	}
+	assert.Equal(t, "success", labels["status"])
+}
 
 func TestSeedCompletedRunsCounter(t *testing.T) {
 	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour)


### PR DESCRIPTION
## What

Add `dagster_last_run_info{job_name, location, status} = 1`, and a Grafana table panel that fills the empty bottom-right slot on the dashboard showing each job's latest run status (color-mapped success/failure).

## Why

Neither `dagster_active_runs` nor `dagster_completed_runs_total` can answer "what was the result of the last run for this job" via PromQL — the counter only tracks increments over time, it doesn't expose current state. `dagster_last_run_info` is an info-style metric (same pattern as `kube_pod_info`: value always 1, the actual information lives in the `status` label), matching the label-based `status` convention already used by the other two metrics rather than encoding it as a number.

Computed by comparing `endTime` across the existing completed-runs query results each scrape (no new GraphQL query needed) and keeping the most recent one per `(job_name, location)`.

Verified locally against a real `dagster dev` instance — `/metrics` correctly shows one series per job at value 1 with the expected status label.

## QA

## Ref

Suggested by ChatGPT as a dashboard addition; implemented here as a new exporter metric since PromQL alone can't derive this from the existing metrics.