### PR TITLE
Remove Go Report Card badge (service sunset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # dagster-prometheus-exporter
 
 [![CI](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/HirofumiTsuda/dagster-prometheus-exporter)](https://goreportcard.com/report/github.com/HirofumiTsuda/dagster-prometheus-exporter)
 [![License: MIT](https://img.shields.io/github/license/HirofumiTsuda/dagster-prometheus-exporter)](LICENSE)
 
 A Prometheus exporter for [Dagster](https://dagster.io/) run metrics. It polls Dagster's GraphQL API on an interval and exposes run counts, statuses, and code-location information as Prometheus metrics.


### PR DESCRIPTION
## What

Remove the Go Report Card badge from the README.

## Why

goreportcard.com has been sunset — the report page now shows a shutdown notice instead of a grade, so the badge is dead weight.

## QA

## Ref