### PR TITLE
Only run CI when Go-relevant files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,26 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - "**.go"
+              - go.mod
+              - go.sum
+              - .github/workflows/ci.yml
+
   test:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +42,8 @@ jobs:
       - run: go test ./...
 
   lint:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Skip the `test`/`lint` jobs when a push or PR doesn't touch Go-relevant files (`**.go`, `go.mod`, `go.sum`, or the workflow file itself), using a `changes` job (`dorny/paths-filter`) plus `if:` conditions on the two jobs.

## Why

CI currently always runs build/vet/test/lint even for changes like README or Grafana dashboard JSON edits, which is wasted time. Using `if:` (rather than a `paths:` filter on the trigger) means the workflow always fires and the jobs report `skipped` instead of never running — so this stays safe even if a required-status-check branch protection rule is added later (not required today, per discussion, but this way it won't silently break in the future).

## QA

## Ref