### PR TITLE
Show location label in Grafana dashboard legends

### DIFF
--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -83,7 +83,7 @@
       "targets": [
         {
           "expr": "dagster_active_runs",
-          "legendFormat": "{{job_name}} {{status}}"
+          "legendFormat": "{{job_name}} ({{location}}) {{status}}"
         }
       ],
       "gridPos": {
@@ -99,7 +99,7 @@
       "targets": [
         {
           "expr": "dagster_completed_runs_total",
-          "legendFormat": "{{job_name}} {{status}}"
+          "legendFormat": "{{job_name}} ({{location}}) {{status}}"
         }
       ],
       "gridPos": {
@@ -114,8 +114,8 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by(job_name)(increase(dagster_completed_runs_total{status=\"failure\"}[5m]))",
-          "legendFormat": "{{job_name}}"
+          "expr": "sum by(job_name, location)(increase(dagster_completed_runs_total{status=\"failure\"}[5m]))",
+          "legendFormat": "{{job_name}} ({{location}})"
         }
       ],
       "gridPos": {


### PR DESCRIPTION
## What

Add `{{location}}` to the legend format of the "Active Runs by Job and Status" and "Completed Runs by Job and Status" panels, and change "Failed Runs (last 5m)"'s `sum by(job_name)` to `sum by(job_name, location)`.

## Why

The `location` label was added to `dagster_active_runs`/`dagster_completed_runs_total` a while back, but the dashboard JSON was never updated to show it — so e.g. active runs showed as "failing_job queued" with no way to tell which code location it came from, even though the underlying series has the label.

## QA

## Ref