### PR TITLE
Fix dagster_last_run_info disappearing and stale locations lingering forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All metrics are labeled with `job_name` and `location` (the Dagster code locatio
 | --- | --- | --- | --- |
 | `dagster_active_runs` | Gauge | `job_name`, `location`, `status` | Number of currently active runs (`queued`, `starting`, `started`) per job. Jobs with no active runs are reported as `0` rather than omitted. |
 | `dagster_completed_runs_total` | Counter | `job_name`, `location`, `status` | Total number of completed runs (`success`, `failure`) per job, since the exporter started. Jobs that have never run are seeded at `0`. Series for jobs that no longer exist in Dagster are deleted automatically. |
-| `dagster_last_run_info` | Gauge | `job_name`, `location`, `status` | Always `1`; an "info" metric (same pattern as `kube_pod_info`) reporting the status of the most recently completed run per job within the lookback window. Use the `status` label to tell success from failure, e.g. in a Grafana table panel. |
+| `dagster_last_run_info` | Gauge | `job_name`, `location`, `status` | Always `1`; an "info" metric (same pattern as `kube_pod_info`) reporting the status of the most recently completed run per job. Kept until a newer completion supersedes it or the job is removed from Dagster — it does not disappear just because nothing has completed recently. Use the `status` label to tell success from failure, e.g. in a Grafana table panel. |
 
 The exporter also exposes `/healthz` (process liveness) and `/readyz` (checks connectivity to the Dagster GraphQL endpoint).
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -18,12 +18,13 @@ type DagsterCollector struct {
 	completedRunsCounter *prometheus.CounterVec
 	lastRunStatusDesc    *prometheus.Desc
 
-	mutex            sync.Mutex
-	activeRunsCounts map[ActiveRunKey]int
-	processedRuns    *ttlcache.Cache[string, struct{}]
-	lookbackWindow   time.Duration
-	knownJobs        map[JobKey]struct{}
-	lastRunStatus    map[JobKey]string
+	mutex                   sync.Mutex
+	activeRunsCounts        map[ActiveRunKey]int
+	processedRuns           *ttlcache.Cache[string, struct{}]
+	lookbackWindow          time.Duration
+	knownJobs               map[JobKey]struct{}
+	lastRunStatus           map[JobKey]lastRunEntry
+	trackedCompletedRunKeys map[JobKey]struct{}
 }
 
 func newDagsterCache(ctx context.Context, cacheTTL time.Duration) *ttlcache.Cache[string, struct{}] {
@@ -60,12 +61,14 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 		),
 		lastRunStatusDesc: prometheus.NewDesc(
 			"dagster_last_run_info",
-			"Status of the most recently completed run for a job within the lookback window (value is always 1; status is carried in the status label)",
+			"Status of the most recently completed run for a job (value is always 1; status is carried in the status label)",
 			[]string{"job_name", "location", "status"},
 			nil,
 		),
-		processedRuns:  cache,
-		lookbackWindow: lookbackWindow,
+		processedRuns:           cache,
+		lookbackWindow:          lookbackWindow,
+		lastRunStatus:           make(map[JobKey]lastRunEntry),
+		trackedCompletedRunKeys: make(map[JobKey]struct{}),
 	}
 }
 

--- a/internal/collector/completed_runs.go
+++ b/internal/collector/completed_runs.go
@@ -39,11 +39,6 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) {
 		log.Printf("failed to collect active runs from dagster: %v", err)
 		return
 	}
-	type latestRun struct {
-		status  string
-		endTime float64
-	}
-	latest := make(map[JobKey]latestRun)
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -55,8 +50,8 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) {
 		}
 
 		key := JobKey{JobName: result.JobName, LocationName: location}
-		if current, ok := latest[key]; !ok || result.EndTime > current.endTime {
-			latest[key] = latestRun{status: result.Status, endTime: result.EndTime}
+		if current, ok := c.lastRunStatus[key]; !ok || result.EndTime > current.endTime {
+			c.lastRunStatus[key] = lastRunEntry{status: result.Status, endTime: result.EndTime}
 		}
 
 		if item := c.processedRuns.Get(result.RunId); item != nil {
@@ -66,27 +61,41 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) {
 		c.processedRuns.Set(result.RunId, struct{}{}, ttlcache.DefaultTTL)
 
 		c.completedRunsCounter.WithLabelValues(result.JobName, location, strings.ToLower(result.Status)).Inc()
+		c.trackedCompletedRunKeys[key] = struct{}{}
 	}
+}
 
-	lastRunStatus := make(map[JobKey]string, len(latest))
-	for key, run := range latest {
-		lastRunStatus[key] = run.status
-	}
-	c.lastRunStatus = lastRunStatus
+// lastRunEntry tracks the status of the most recently completed run seen so
+// far for a job, so dagster_last_run_info keeps reporting it even after the
+// run falls outside the completed-runs lookback window.
+type lastRunEntry struct {
+	status  string
+	endTime float64
 }
 
 func reflectLastRunStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	for key, status := range c.lastRunStatus {
+	for key, entry := range c.lastRunStatus {
 		ch <- prometheus.MustNewConstMetric(
 			c.lastRunStatusDesc,
 			prometheus.GaugeValue,
 			1,
 			key.JobName,
 			key.LocationName,
-			strings.ToLower(status),
+			strings.ToLower(entry.status),
 		)
+	}
+}
+
+// pruneLastRunStatus deletes cached last-run status for jobs that no longer
+// exist, so dagster_last_run_info doesn't keep reporting stale entries
+// forever for removed jobs. Callers must hold c.mutex.
+func pruneLastRunStatus(c *DagsterCollector, known map[JobKey]struct{}) {
+	for key := range c.lastRunStatus {
+		if _, ok := known[key]; !ok {
+			delete(c.lastRunStatus, key)
+		}
 	}
 }
 
@@ -98,19 +107,24 @@ func seedCompletedRunsCounter(c *DagsterCollector, known map[JobKey]struct{}) {
 		for _, status := range completedStatuses {
 			c.completedRunsCounter.WithLabelValues(key.JobName, key.LocationName, strings.ToLower(status)).Add(0)
 		}
+		c.trackedCompletedRunKeys[key] = struct{}{}
 	}
 }
 
-// pruneCompletedRunsCounter deletes series for jobs that existed in previous
-// but no longer exist in known, so metrics for removed jobs stop being reported.
+// pruneCompletedRunsCounter deletes every tracked (job, location) series that
+// isn't in known. This covers both jobs removed from Dagster and runs whose
+// repositoryOrigin recorded a location name (e.g. an old, since-renamed
+// auto-generated grpc location name) that never matches a live location, so
+// those don't linger in dagster_completed_runs_total forever.
 // Callers must hold c.mutex.
-func pruneCompletedRunsCounter(c *DagsterCollector, previous, known map[JobKey]struct{}) {
-	for key := range previous {
+func pruneCompletedRunsCounter(c *DagsterCollector, known map[JobKey]struct{}) {
+	for key := range c.trackedCompletedRunKeys {
 		if _, ok := known[key]; ok {
 			continue
 		}
 		for _, status := range completedStatuses {
 			c.completedRunsCounter.DeleteLabelValues(key.JobName, key.LocationName, strings.ToLower(status))
 		}
+		delete(c.trackedCompletedRunKeys, key)
 	}
 }

--- a/internal/collector/completed_runs_test.go
+++ b/internal/collector/completed_runs_test.go
@@ -38,7 +38,7 @@ func TestCollectCompletedRunsTracksLastRunStatus(t *testing.T) {
 	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
 	CollectCompletedRuns(t.Context(), c)
 
-	assert.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}])
+	assert.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}].status)
 
 	ch := make(chan prometheus.Metric, 8)
 	go func() {
@@ -61,6 +61,67 @@ func TestCollectCompletedRunsTracksLastRunStatus(t *testing.T) {
 		labels[l.GetName()] = l.GetValue()
 	}
 	assert.Equal(t, "success", labels["status"])
+}
+
+func TestLastRunStatusPersistsAfterFallingOutOfLookbackWindow(t *testing.T) {
+	call := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		body := `{
+			"data": {
+				"runsOrError": {
+					"__typename": "Runs",
+					"results": [
+						{"runId": "run_1", "jobName": "job_a", "status": "SUCCESS", "endTime": 100, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "loc_a"}}
+					]
+				}
+			}
+		}`
+		if call > 1 {
+			// Simulate the run aging out of the completed-runs lookback window:
+			// the query now returns no results at all.
+			body = `{
+				"data": {
+					"runsOrError": {
+						"__typename": "Runs",
+						"results": []
+					}
+				}
+			}`
+		}
+
+		_, err := w.Write([]byte(body))
+		if err != nil {
+			t.Fatalf("failed to write mock response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+
+	CollectCompletedRuns(t.Context(), c)
+	require.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}].status)
+
+	CollectCompletedRuns(t.Context(), c)
+	assert.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}].status,
+		"last known status should survive a scrape with no completed runs in range")
+}
+
+func TestPruneLastRunStatus(t *testing.T) {
+	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour)
+
+	goneKey := JobKey{JobName: "gone_job", LocationName: "loc_a"}
+	stillHereKey := JobKey{JobName: "job_a", LocationName: "loc_a"}
+	c.lastRunStatus[goneKey] = lastRunEntry{status: "SUCCESS", endTime: 100}
+	c.lastRunStatus[stillHereKey] = lastRunEntry{status: "FAILURE", endTime: 100}
+
+	pruneLastRunStatus(c, map[JobKey]struct{}{stillHereKey: {}})
+
+	assert.NotContains(t, c.lastRunStatus, goneKey)
+	assert.Contains(t, c.lastRunStatus, stillHereKey)
 }
 
 func TestSeedCompletedRunsCounter(t *testing.T) {
@@ -88,7 +149,7 @@ func TestPruneCompletedRunsCounter(t *testing.T) {
 	known := map[JobKey]struct{}{}
 
 	seedCompletedRunsCounter(c, previous)
-	pruneCompletedRunsCounter(c, previous, known)
+	pruneCompletedRunsCounter(c, known)
 
 	ch := make(chan prometheus.Metric, 8)
 	go func() {
@@ -101,6 +162,60 @@ func TestPruneCompletedRunsCounter(t *testing.T) {
 		count++
 	}
 	assert.Equal(t, 0, count, "expected no series to remain for a pruned job")
+}
+
+func TestPruneCompletedRunsCounterRemovesStaleLocationNotInRoster(t *testing.T) {
+	// Regression test: a run whose repositoryOrigin recorded an old location
+	// name (e.g. an auto-generated grpc name from before location_name was
+	// pinned) must not linger in dagster_completed_runs_total forever just
+	// because that (job, location) pair never appears in the live roster.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+			"data": {
+				"runsOrError": {
+					"__typename": "Runs",
+					"results": [
+						{"runId": "run_1", "jobName": "job_a", "status": "SUCCESS", "endTime": 100, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "old.module.path"}}
+					]
+				}
+			}
+		}`))
+		if err != nil {
+			t.Fatalf("failed to write mock response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	CollectCompletedRuns(t.Context(), c)
+
+	metric, err := c.completedRunsCounter.GetMetricWithLabelValues("job_a", "old.module.path", "success")
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(metric))
+
+	// The live roster now reports "job_a" under a renamed, pinned location.
+	known := map[JobKey]struct{}{
+		{JobName: "job_a", LocationName: "current-location"}: {},
+	}
+	pruneCompletedRunsCounter(c, known)
+
+	ch := make(chan prometheus.Metric, 8)
+	go func() {
+		c.completedRunsCounter.Collect(ch)
+		close(ch)
+	}()
+
+	for m := range ch {
+		var dm dto.Metric
+		require.NoError(t, m.Write(&dm))
+		for _, l := range dm.GetLabel() {
+			if l.GetName() == "location" {
+				assert.NotEqual(t, "old.module.path", l.GetValue(), "stale location series should have been pruned")
+			}
+		}
+	}
 }
 
 func TestCollectJobLocationsSeedsAndPrunes(t *testing.T) {

--- a/internal/collector/job_locations.go
+++ b/internal/collector/job_locations.go
@@ -29,9 +29,9 @@ func CollectJobLocations(ctx context.Context, c *DagsterCollector) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	previous := c.knownJobs
 	c.knownJobs = known
 
-	pruneCompletedRunsCounter(c, previous, known)
+	pruneCompletedRunsCounter(c, known)
 	seedCompletedRunsCounter(c, known)
+	pruneLastRunStatus(c, known)
 }


### PR DESCRIPTION
## What

Two related fixes to how completed-run state is tracked in `internal/collector`:

1. `dagster_last_run_info` no longer disappears once nothing has completed within the lookback window — it's updated in place (only overwritten by a newer completion) and only cleared once the job/location is confirmed gone from the live roster.
2. `dagster_completed_runs_total` no longer keeps a stale `(job, location)` series forever if that location was never part of the live roster to begin with (e.g. an old auto-generated grpc location name from before `location_name` was pinned) — every series ever created is now tracked directly and pruned against the current roster.

## Why

Reported while testing the dashboard: "Completed Runs by Job and Status" showed an old location name (`dev.dagster_workspace.definitions`) that no longer matches the live, pinned location name (`dev-dagster-workspace`). Root cause: pruning only ever diffed the previous vs. current roster *snapshot*, so a series created directly from a run's own `repositoryOrigin` location (which was never part of any roster snapshot) was invisible to that diff and never got cleaned up.

While investigating, also found `dagster_last_run_info` had the opposite problem — it was fully rebuilt from the lookback-windowed query every scrape, so it would blink out of existence for any job with no completions in the last `LOOKBACK_WINDOW_MINUTES`, even though the job's last known status hadn't changed.

## QA

Added `TestPruneCompletedRunsCounterRemovesStaleLocationNotInRoster` (reproduces the exact reported scenario) and `TestLastRunStatusPersistsAfterFallingOutOfLookbackWindow`.

## Ref