### PR TITLE
Make context the single source of truth for GraphQL request timeouts

### DIFF
--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -8,10 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 )
-
-const timeOut = 10
 
 type GraphQLRequest struct {
 	Query     string                 `json:"query"`
@@ -74,9 +71,9 @@ func getRuns(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoin
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{
-		Timeout: timeOut * time.Second,
-	}
+	// Timeout is intentionally not set here: the caller controls how long a
+	// request may run via ctx (see http.NewRequestWithContext above).
+	client := &http.Client{}
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute http request: %w", err)
@@ -142,9 +139,9 @@ func getJobLocations(ctx context.Context, request *GraphQLRequest, dagsterGraphQ
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{
-		Timeout: timeOut * time.Second,
-	}
+	// Timeout is intentionally not set here: the caller controls how long a
+	// request may run via ctx (see http.NewRequestWithContext above).
+	client := &http.Client{}
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute http request: %w", err)
@@ -196,9 +193,9 @@ func GetVersion(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndp
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{
-		Timeout: timeOut * time.Second,
-	}
+	// Timeout is intentionally not set here: the caller controls how long a
+	// request may run via ctx (see http.NewRequestWithContext above).
+	client := &http.Client{}
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute http request: %w", err)

--- a/internal/collector/graphql_test.go
+++ b/internal/collector/graphql_test.go
@@ -1,10 +1,12 @@
 package collector
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,6 +113,33 @@ func TestGetRuns(t *testing.T) {
 	assert.Equal(t, "STARTED", result.Status)
 	require.NotNil(t, result.RepositoryOrigin)
 	assert.Equal(t, "test_location", result.RepositoryOrigin.RepositoryLocationName)
+}
+
+func TestGetRunsRespectsContextTimeout(t *testing.T) {
+	unblock := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a Dagster instance that never responds in time. There is
+		// no http.Client-level Timeout anymore (see graphql.go) — ctx must
+		// be the only thing that can end this request.
+		<-unblock
+	}))
+	// unblock must be closed before ts.Close(), since Close() waits for the
+	// in-flight handler above to return.
+	defer ts.Close()
+	defer close(unblock)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	req := getRunsRequest(nil, 0.0)
+
+	start := time.Now()
+	_, err := getRuns(ctx, req, ts.URL)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 2*time.Second, "request should have been cancelled by the context deadline, not left to hang")
 }
 
 func TestGetRunsWithServerError(t *testing.T) {

--- a/internal/server/readyz.go
+++ b/internal/server/readyz.go
@@ -6,10 +6,14 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"time"
 )
 
-func newReadyzHandler(ctx context.Context, dagsterGraphQLEndpoint string) http.Handler {
+func newReadyzHandler(dagsterGraphQLEndpoint string, timeout time.Duration) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+
 		req := collector.GetVersionRequest()
 
 		resp, err := collector.GetVersion(ctx, req, dagsterGraphQLEndpoint)

--- a/internal/server/scrape.go
+++ b/internal/server/scrape.go
@@ -13,13 +13,19 @@ func scrapeDagster(ctx context.Context, c *collector.DagsterCollector) {
 	collector.CollectCompletedRuns(ctx, c)
 }
 
+func scrapeDagsterWithTimeout(ctx context.Context, c *collector.DagsterCollector, timeout time.Duration) {
+	scrapeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	scrapeDagster(scrapeCtx, c)
+}
+
 func startScrape(ctx context.Context, c *collector.DagsterCollector, interval time.Duration, timeout time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	log.Printf("Starting background scraper (interval: %v)...", interval)
 
-	scrapeDagster(ctx, c)
+	scrapeDagsterWithTimeout(ctx, c, timeout)
 
 	for {
 		select {
@@ -29,11 +35,7 @@ func startScrape(ctx context.Context, c *collector.DagsterCollector, interval ti
 			return
 
 		case <-ticker.C:
-			func() {
-				scrapeCtx, cancel := context.WithTimeout(ctx, timeout)
-				defer cancel()
-				scrapeDagster(scrapeCtx, c)
-			}()
+			scrapeDagsterWithTimeout(ctx, c, timeout)
 		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,7 +21,7 @@ func RunServer(ctx context.Context, config *config.Config) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/healthz", healthzHandler)
-	mux.Handle("/readyz", newReadyzHandler(ctx, config.DagsterGraphQLEndpoint))
+	mux.Handle("/readyz", newReadyzHandler(config.DagsterGraphQLEndpoint, config.DagsterScrapingTimeout))
 
 	srv := &http.Server{
 		Addr:    portSuffix,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,7 +32,7 @@ func TestNewReadyzHandlerSuccess(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	handler := newReadyzHandler(t.Context(), ts.URL)
+	handler := newReadyzHandler(ts.URL, time.Second)
 	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
 
@@ -41,13 +42,36 @@ func TestNewReadyzHandlerSuccess(t *testing.T) {
 	assert.JSONEq(t, `{"status":"OK","version":"1.2.3"}`, rec.Body.String())
 }
 
+func TestNewReadyzHandlerTimesOutOnSlowDagster(t *testing.T) {
+	unblock := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-unblock
+	}))
+	// unblock must be closed before ts.Close(), since Close() waits for the
+	// in-flight handler above to return.
+	defer ts.Close()
+	defer close(unblock)
+
+	handler := newReadyzHandler(ts.URL, 50*time.Millisecond)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	start := time.Now()
+	handler.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Less(t, elapsed, 2*time.Second, "handler should have been bounded by its own timeout, not hung on a slow Dagster")
+}
+
 func TestNewReadyzHandlerFailure(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
 
-	handler := newReadyzHandler(t.Context(), ts.URL)
+	handler := newReadyzHandler(ts.URL, time.Second)
 	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
 


### PR DESCRIPTION
## What

Remove the hardcoded `http.Client{Timeout: 10s}` from `getRuns`/`getJobLocations`/`GetVersion` so `ctx` is the only thing that can end a request, and fix the two spots that didn't actually establish a context deadline (so they could otherwise hang indefinitely now that the client-level timeout is gone).

## Why

Every GraphQL call built its own `http.Client` with a hardcoded 10s `Timeout`, completely independent of the `ctx` passed in. Since context cancellation and the client's own `Timeout` both apply and whichever fires first wins, that hardcoded value silently capped every call regardless of what the caller's context deadline actually was — there was no way to control the timeout via context at all.

Removing it exposed two real gaps:
- `startScrape`'s very first scrape (before the ticker loop starts) used a raw ctx with no deadline.
- `/readyz` reused the server's whole-lifetime context for every request, so a slow Dagster could hang a readiness check forever.

Both now get a bounded context explicitly.

## QA

Added `TestGetRunsRespectsContextTimeout` and `TestNewReadyzHandlerTimesOutOnSlowDagster`, each using a mock server that never responds, to prove the request actually gets cut off by ctx (previously masked by the 10s client timeout in these tests' timescale, but would matter for a longer configured timeout).

## Ref

Addresses the context/timeout item in the リファクタリング系 section of TODO.md (not committed).