### PR TITLE
Run the three scrape collectors concurrently

### DIFF
--- a/internal/server/scrape.go
+++ b/internal/server/scrape.go
@@ -4,13 +4,30 @@ import (
 	"context"
 	"dagster-prometheus-exporter/internal/collector"
 	"log"
+	"sync"
 	"time"
 )
 
+// scrapeDagster runs the GraphQL-backed collectors concurrently. Each one
+// locks DagsterCollector's own mutex around its critical section, so running
+// them in parallel is safe; doing so bounds the total scrape latency by the
+// slowest single call instead of their sum.
 func scrapeDagster(ctx context.Context, c *collector.DagsterCollector) {
-	collector.CollectJobLocations(ctx, c)
-	collector.CollectActiveRuns(ctx, c)
-	collector.CollectCompletedRuns(ctx, c)
+	var wg sync.WaitGroup
+
+	spawn := func(fn func()) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fn()
+		}()
+	}
+
+	spawn(func() { collector.CollectJobLocations(ctx, c) })
+	spawn(func() { collector.CollectActiveRuns(ctx, c) })
+	spawn(func() { collector.CollectCompletedRuns(ctx, c) })
+
+	wg.Wait()
 }
 
 func scrapeDagsterWithTimeout(ctx context.Context, c *collector.DagsterCollector, timeout time.Duration) {

--- a/internal/server/scrape_test.go
+++ b/internal/server/scrape_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"dagster-prometheus-exporter/internal/collector"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScrapeDagsterRunsCollectorsConcurrently(t *testing.T) {
+	const perRequestDelay = 50 * time.Millisecond
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(perRequestDelay)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Valid enough for both GraphQLRunsResponse and
+		// GraphQLJobLocationsResponse decoding, whichever collector hits it.
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"runsOrError": {"__typename": "Runs", "results": []},
+				"repositoriesOrError": {"__typename": "RepositoryConnection", "nodes": []}
+			}
+		}`))
+	}))
+	defer ts.Close()
+
+	c := collector.NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+
+	start := time.Now()
+	scrapeDagster(t.Context(), c)
+	elapsed := time.Since(start)
+
+	// Sequentially, three calls at perRequestDelay each would take ~150ms.
+	// Running them concurrently should take roughly one delay's worth.
+	assert.Less(t, elapsed, 2*perRequestDelay, "collectors should run concurrently, not sequentially")
+}


### PR DESCRIPTION
## What

Run `CollectJobLocations`, `CollectActiveRuns`, and `CollectCompletedRuns` concurrently in `scrapeDagster` instead of sequentially.

## Why

Each collector already locks `DagsterCollector`'s own mutex around its critical section, so running them in parallel is safe. This bounds total scrape latency to the slowest single GraphQL call instead of their sum — which matters now that all three share one timeout budget (#12).

## QA

Added `TestScrapeDagsterRunsCollectorsConcurrently`, which points all three collectors at a mock server with an artificial per-request delay and asserts the total time is close to one delay, not three. Verified with `go test -race` (including 20x repeated runs) — no races.

## Ref

Addresses the parallel-execution part of the scraping-optimization item in TODO.md (not committed).