### PR TITLE
Add CodeQL static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * 1"
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: go
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## What

Add a CodeQL workflow that scans the Go code for security issues on push/PR to `main` and on a weekly schedule.

## Why

Free for public repos, low maintenance, gives an OSS security signal. This project's attack surface is small (no SQL, templating, or auth), but the cost of having it is close to zero.

## QA

## Ref

Addresses the CodeQL item in the 運用/OSS整備系 section of TODO.md (not committed).