### PR TITLE
Add Dependabot for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Add `.github/dependabot.yml` watching `go.mod`/`go.sum` (gomod ecosystem) and the GitHub Actions workflow files, weekly, with updates grouped into one PR per ecosystem.

## Why

Automated, reviewable dependency-update PRs — free for public repos. Grouping + weekly cadence keeps PR noise manageable for a solo-maintained project. Updates still land as PRs to review/merge, not automatic floating versions, consistent with the explicit version pins already used in ci.yml.

## QA

## Ref

Addresses the Dependabot item in the 運用/OSS整備系 section of TODO.md (not committed).