### PR TITLE
Fetch runs incrementally with cursor-paginated, streaming reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ The exporter is a single Go binary with no external state store — everything i
 
 Because scraping (writing state) and metrics rendering (reading state) are decoupled, a slow or failing Dagster GraphQL call never blocks or breaks a `/metrics` request — it just serves the last known state.
 
+The three collectors (job/location roster, active runs, completed runs) run concurrently on every scrape — each locks `DagsterCollector`'s own mutex only around its own critical section, so they don't block each other or `/metrics`.
+
+Fetching completed runs is incremental, not a full re-scan every cycle: after the first scrape (which backfills `LOOKBACK_WINDOW_MINUTES`), each subsequent scrape only asks Dagster for runs updated since the last-seen watermark (minus a small safety margin, to tolerate a run's DB write committing slightly after its `updateTime`). Any single fetch — the initial backfill or an unusually large batch of updates — pages through `runsOrError` via cursor (`RUNS_PAGE_SIZE` per page) and folds each page into the in-memory counters as it arrives, rather than buffering the full result set in memory first.
+
 ## Metrics
 
 All metrics are labeled with `job_name` and `location` (the Dagster code location the job belongs to), so that jobs with the same name in different code locations don't collide.
@@ -146,9 +150,12 @@ All configuration is via environment variables (see `internal/config/config.go`)
 | --- | --- | --- |
 | `PORT` | `9101` | Port the exporter listens on. |
 | `DAGSTER_GRAPHQL_ENDPOINT` | `http://127.0.0.1:3000/graphql` | URL of the Dagster GraphQL API to poll. |
-| `LOOKBACK_WINDOW_MINUTES` | `720` (12h) | How far back to look for completed runs on each scrape. |
+| `LOOKBACK_WINDOW_MINUTES` | scraping interval | How far back to look for completed runs on the very first scrape only. After that, completed runs are fetched incrementally from the last-seen update time (see [Architecture](#architecture)), so this only matters for the initial backfill on startup. |
 | `CACHE_TTL_MINUTES` | `1440` (24h) | How long a completed run's ID is remembered, to avoid double-counting `dagster_completed_runs_total`. |
 | `DAGSTER_SCRAPING_INTERVAL_SECONDS` | `15` | How often the exporter polls Dagster's GraphQL API. |
+| `DAGSTER_SCRAPING_TIMEOUT_SECONDS` | `10` | Timeout for a full scrape cycle (all three collectors, run concurrently). |
+| `RUNS_PAGE_SIZE` | `500` | Max runs requested per GraphQL call; larger result sets are paged through via cursor. |
+| `RUNS_UPDATED_AFTER_SAFETY_MARGIN_MINUTES` | `5` | Overlap subtracted from the incremental fetch watermark, to tolerate runs whose DB commit lands slightly after their `updateTime`. |
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ All configuration is via environment variables (see `internal/config/config.go`)
 | `PORT` | `9101` | Port the exporter listens on. |
 | `DAGSTER_GRAPHQL_ENDPOINT` | `http://127.0.0.1:3000/graphql` | URL of the Dagster GraphQL API to poll. |
 | `LOOKBACK_WINDOW_MINUTES` | scraping interval | How far back to look for completed runs on the very first scrape only. After that, completed runs are fetched incrementally from the last-seen update time (see [Architecture](#architecture)), so this only matters for the initial backfill on startup. |
-| `CACHE_TTL_MINUTES` | `1440` (24h) | How long a completed run's ID is remembered, to avoid double-counting `dagster_completed_runs_total`. |
+| `CACHE_TTL_MINUTES` | 20x the scraping interval | How long a completed run's ID is remembered, to avoid double-counting `dagster_completed_runs_total`. A still-relevant run gets touched (its TTL refreshed) on every scrape, so this really just bounds how many consecutive missed/failed scrapes are tolerated before risking a double count on recovery. |
 | `DAGSTER_SCRAPING_INTERVAL_SECONDS` | `15` | How often the exporter polls Dagster's GraphQL API. |
 | `DAGSTER_SCRAPING_TIMEOUT_SECONDS` | `10` | Timeout for a full scrape cycle (all three collectors, run concurrently). |
 | `RUNS_PAGE_SIZE` | `500` | Max runs requested per GraphQL call; larger result sets are paged through via cursor. |

--- a/internal/collector/active_runs.go
+++ b/internal/collector/active_runs.go
@@ -18,40 +18,29 @@ type ActiveRunKey struct {
 	Status       string
 }
 
-func getActiveRunsRequest() *GraphQLRequest {
-	variables := map[string]interface{}{
-		"statuses":     activeStatuses,
-		"updatedAfter": nil,
-	}
-	return &GraphQLRequest{
-		Query:     runsQuery,
-		Variables: variables,
-	}
-}
-
 func CollectActiveRuns(ctx context.Context, c *DagsterCollector) {
-	req := getActiveRunsRequest()
+	counts := make(map[ActiveRunKey]int)
 
-	resp, err := getRuns(ctx, req, c.dagsterGraphQLEndpoint)
+	err := fetchRunPages(ctx, activeStatuses, 0, c.dagsterGraphQLEndpoint, c.runsPageSize, func(page []Run) error {
+		for _, run := range page {
+			location := unknownLocationName
+			if run.RepositoryOrigin != nil {
+				location = run.RepositoryOrigin.RepositoryLocationName
+			}
+			key := ActiveRunKey{
+				JobName:      run.JobName,
+				LocationName: location,
+				Status:       run.Status,
+			}
+			counts[key]++
+		}
+		return nil
+	})
 	if err != nil {
 		log.Printf("failed to collect active runs from dagster: %v", err)
 		return
 	}
 
-	counts := make(map[ActiveRunKey]int)
-
-	for _, run := range resp.Data.RunsOrError.Results {
-		location := unknownLocationName
-		if run.RepositoryOrigin != nil {
-			location = run.RepositoryOrigin.RepositoryLocationName
-		}
-		key := ActiveRunKey{
-			JobName:      run.JobName,
-			LocationName: location,
-			Status:       run.Status,
-		}
-		counts[key]++
-	}
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 

--- a/internal/collector/active_runs_test.go
+++ b/internal/collector/active_runs_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetActiveRunsRequest(t *testing.T) {
-	reqBody := getActiveRunsRequest()
-	if reqBody.Query == "" {
-		t.Fatal("reqBody.Query must not be empty")
-	}
-	assert.Equal(t, activeStatuses, reqBody.Variables["statuses"])
-}
-
 func TestCollectActiveRunsLocationLabel(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -38,7 +30,7 @@ func TestCollectActiveRunsLocationLabel(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 	CollectActiveRuns(t.Context(), c)
 
 	assert.Equal(t, 1, c.activeRunsCounts[ActiveRunKey{JobName: "job_a", LocationName: "loc_a", Status: "STARTED"}])
@@ -63,7 +55,7 @@ func TestCollectActiveRunsZeroFillsKnownJobs(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 	c.knownJobs = map[JobKey]struct{}{
 		{JobName: "never_run_job", LocationName: "loc_a"}: {},
 	}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -18,13 +18,25 @@ type DagsterCollector struct {
 	completedRunsCounter *prometheus.CounterVec
 	lastRunStatusDesc    *prometheus.Desc
 
-	mutex                   sync.Mutex
-	activeRunsCounts        map[ActiveRunKey]int
-	processedRuns           *ttlcache.Cache[string, struct{}]
-	lookbackWindow          time.Duration
-	knownJobs               map[JobKey]struct{}
-	lastRunStatus           map[JobKey]lastRunEntry
-	trackedCompletedRunKeys map[JobKey]struct{}
+	mutex                        sync.Mutex
+	activeRunsCounts             map[ActiveRunKey]int
+	processedRuns                *ttlcache.Cache[string, struct{}]
+	lookbackWindow               time.Duration
+	knownJobs                    map[JobKey]struct{}
+	lastRunStatus                map[JobKey]lastRunEntry
+	trackedCompletedRunKeys      map[JobKey]struct{}
+	lastSeenUpdateTime           float64
+	runsPageSize                 int
+	// runsUpdatedAfterSafetyMargin is subtracted from the last-seen
+	// updateTime watermark before it's used as the next scrape's
+	// updatedAfter. A run's updateTime can be set slightly before its write
+	// is actually committed and visible to us, so advancing the watermark
+	// to the exact max we've observed risks permanently skipping a run
+	// whose commit was delayed past that point. Re-fetching this small
+	// overlap window each time is cheap and harmless: processedRuns and
+	// lastRunStatus's newest-wins comparison already make reprocessing an
+	// already-seen run a no-op.
+	runsUpdatedAfterSafetyMargin time.Duration
 }
 
 func newDagsterCache(ctx context.Context, cacheTTL time.Duration) *ttlcache.Cache[string, struct{}] {
@@ -42,7 +54,7 @@ func newDagsterCache(ctx context.Context, cacheTTL time.Duration) *ttlcache.Cach
 	return cache
 }
 
-func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, lookbackWindow time.Duration, cacheTTL time.Duration) *DagsterCollector {
+func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, lookbackWindow time.Duration, cacheTTL time.Duration, runsPageSize int, runsUpdatedAfterSafetyMargin time.Duration) *DagsterCollector {
 	cache := newDagsterCache(ctx, cacheTTL)
 	return &DagsterCollector{
 		dagsterGraphQLEndpoint: dagsterGraphQLEndpoint,
@@ -65,10 +77,12 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"job_name", "location", "status"},
 			nil,
 		),
-		processedRuns:           cache,
-		lookbackWindow:          lookbackWindow,
-		lastRunStatus:           make(map[JobKey]lastRunEntry),
-		trackedCompletedRunKeys: make(map[JobKey]struct{}),
+		processedRuns:                cache,
+		lookbackWindow:               lookbackWindow,
+		lastRunStatus:                make(map[JobKey]lastRunEntry),
+		trackedCompletedRunKeys:      make(map[JobKey]struct{}),
+		runsPageSize:                 runsPageSize,
+		runsUpdatedAfterSafetyMargin: runsUpdatedAfterSafetyMargin,
 	}
 }
 

--- a/internal/collector/completed_runs.go
+++ b/internal/collector/completed_runs.go
@@ -14,54 +14,61 @@ var (
 	completedStatuses = []string{"FAILURE", "SUCCESS"}
 )
 
-func getCompletedRunsRequest(updatedAfter float64) *GraphQLRequest {
-	variables := map[string]interface{}{
-		"statuses":     completedStatuses,
-		"updatedAfter": updatedAfter,
-	}
-	return &GraphQLRequest{
-		Query:     runsQuery,
-		Variables: variables,
-	}
-}
-
 func getUpdatedAfter(base time.Time, lookbackWindow time.Duration) float64 {
 	return float64(base.Add(-lookbackWindow).Unix())
 }
 
 func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) {
-	now := time.Now()
-	updatedAfter := getUpdatedAfter(now, c.lookbackWindow)
-	req := getCompletedRunsRequest(updatedAfter)
+	c.mutex.Lock()
+	lastSeenUpdateTime := c.lastSeenUpdateTime
+	c.mutex.Unlock()
 
-	resp, err := getRuns(ctx, req, c.dagsterGraphQLEndpoint)
+	updatedAfter := getUpdatedAfter(time.Now(), c.lookbackWindow)
+	if lastSeenUpdateTime > 0 {
+		updatedAfter = lastSeenUpdateTime - c.runsUpdatedAfterSafetyMargin.Seconds()
+	}
+
+	var maxUpdateTimeSeen float64
+
+	err := fetchRunPages(ctx, completedStatuses, updatedAfter, c.dagsterGraphQLEndpoint, c.runsPageSize, func(page []Run) error {
+		c.mutex.Lock()
+		defer c.mutex.Unlock()
+
+		for _, result := range page {
+			if result.UpdateTime > maxUpdateTimeSeen {
+				maxUpdateTimeSeen = result.UpdateTime
+			}
+
+			location := unknownLocationName
+			if result.RepositoryOrigin != nil {
+				location = result.RepositoryOrigin.RepositoryLocationName
+			}
+
+			key := JobKey{JobName: result.JobName, LocationName: location}
+			if current, ok := c.lastRunStatus[key]; !ok || result.EndTime > current.endTime {
+				c.lastRunStatus[key] = lastRunEntry{status: result.Status, endTime: result.EndTime}
+			}
+
+			if item := c.processedRuns.Get(result.RunId); item != nil {
+				continue
+			}
+
+			c.processedRuns.Set(result.RunId, struct{}{}, ttlcache.DefaultTTL)
+
+			c.completedRunsCounter.WithLabelValues(result.JobName, location, strings.ToLower(result.Status)).Inc()
+			c.trackedCompletedRunKeys[key] = struct{}{}
+		}
+		return nil
+	})
 	if err != nil {
-		log.Printf("failed to collect active runs from dagster: %v", err)
+		log.Printf("failed to collect completed runs from dagster: %v", err)
 		return
 	}
 
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	for _, result := range resp.Data.RunsOrError.Results {
-		location := unknownLocationName
-		if result.RepositoryOrigin != nil {
-			location = result.RepositoryOrigin.RepositoryLocationName
-		}
-
-		key := JobKey{JobName: result.JobName, LocationName: location}
-		if current, ok := c.lastRunStatus[key]; !ok || result.EndTime > current.endTime {
-			c.lastRunStatus[key] = lastRunEntry{status: result.Status, endTime: result.EndTime}
-		}
-
-		if item := c.processedRuns.Get(result.RunId); item != nil {
-			continue
-		}
-
-		c.processedRuns.Set(result.RunId, struct{}{}, ttlcache.DefaultTTL)
-
-		c.completedRunsCounter.WithLabelValues(result.JobName, location, strings.ToLower(result.Status)).Inc()
-		c.trackedCompletedRunKeys[key] = struct{}{}
+	if maxUpdateTimeSeen > lastSeenUpdateTime {
+		c.mutex.Lock()
+		c.lastSeenUpdateTime = maxUpdateTimeSeen
+		c.mutex.Unlock()
 	}
 }
 

--- a/internal/collector/completed_runs_test.go
+++ b/internal/collector/completed_runs_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +14,58 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCollectCompletedRunsUsesIncrementalUpdatedAfter(t *testing.T) {
+	var seenUpdatedAfter []float64
+	call := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if v, ok := req.Variables["updatedAfter"]; ok && v != nil {
+			seenUpdatedAfter = append(seenUpdatedAfter, v.(float64))
+		} else {
+			seenUpdatedAfter = append(seenUpdatedAfter, 0)
+		}
+		call++
+
+		body := `{"data": {"runsOrError": {"__typename": "Runs", "results": []}}}`
+		if call == 1 {
+			body = `{
+				"data": {
+					"runsOrError": {
+						"__typename": "Runs",
+						"results": [
+							{"runId": "run_1", "jobName": "job_a", "status": "SUCCESS", "endTime": 100, "updateTime": 1000}
+						]
+					}
+				}
+			}`
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	lookback := 2 * time.Hour
+	safetyMargin := 5 * time.Minute
+	c := NewDagsterCollector(t.Context(), ts.URL, lookback, time.Hour, 500, safetyMargin)
+
+	CollectCompletedRuns(t.Context(), c)
+	require.Len(t, seenUpdatedAfter, 1)
+	expectedFirst := getUpdatedAfter(time.Now(), lookback)
+	assert.InDelta(t, expectedFirst, seenUpdatedAfter[0], 5,
+		"first scrape (no watermark yet) should fall back to the lookback window")
+	assert.Equal(t, float64(1000), c.lastSeenUpdateTime, "watermark should advance to the max updateTime seen")
+
+	CollectCompletedRuns(t.Context(), c)
+	require.Len(t, seenUpdatedAfter, 2)
+	assert.Equal(t, float64(1000)-safetyMargin.Seconds(), seenUpdatedAfter[1],
+		"second scrape should use the watermark minus the safety margin, not the full lookback window again")
+}
 
 func TestCollectCompletedRunsTracksLastRunStatus(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +88,7 @@ func TestCollectCompletedRunsTracksLastRunStatus(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 	CollectCompletedRuns(t.Context(), c)
 
 	assert.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}].status)
@@ -100,7 +153,7 @@ func TestLastRunStatusPersistsAfterFallingOutOfLookbackWindow(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 
 	CollectCompletedRuns(t.Context(), c)
 	require.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}].status)
@@ -111,7 +164,7 @@ func TestLastRunStatusPersistsAfterFallingOutOfLookbackWindow(t *testing.T) {
 }
 
 func TestPruneLastRunStatus(t *testing.T) {
-	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour)
+	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour, 500, 5*time.Minute)
 
 	goneKey := JobKey{JobName: "gone_job", LocationName: "loc_a"}
 	stillHereKey := JobKey{JobName: "job_a", LocationName: "loc_a"}
@@ -125,7 +178,7 @@ func TestPruneLastRunStatus(t *testing.T) {
 }
 
 func TestSeedCompletedRunsCounter(t *testing.T) {
-	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour)
+	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour, 500, 5*time.Minute)
 
 	known := map[JobKey]struct{}{
 		{JobName: "job_a", LocationName: "loc_a"}: {},
@@ -141,7 +194,7 @@ func TestSeedCompletedRunsCounter(t *testing.T) {
 }
 
 func TestPruneCompletedRunsCounter(t *testing.T) {
-	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour)
+	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour, 500, 5*time.Minute)
 
 	previous := map[JobKey]struct{}{
 		{JobName: "gone_job", LocationName: "loc_a"}: {},
@@ -188,7 +241,7 @@ func TestPruneCompletedRunsCounterRemovesStaleLocationNotInRoster(t *testing.T) 
 	}))
 	defer ts.Close()
 
-	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 	CollectCompletedRuns(t.Context(), c)
 
 	metric, err := c.completedRunsCounter.GetMetricWithLabelValues("job_a", "old.module.path", "success")
@@ -253,7 +306,7 @@ func TestCollectJobLocationsSeedsAndPrunes(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 
 	CollectJobLocations(t.Context(), c)
 	assert.Contains(t, c.knownJobs, JobKey{JobName: "job_a", LocationName: "loc_a"})

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -15,24 +15,30 @@ type GraphQLRequest struct {
 	Variables map[string]interface{} `json:"variables,omitempty"`
 }
 
+// RunRepositoryOrigin identifies the code location a Run was launched from,
+// as recorded on the run itself (a launch-time snapshot, not a live lookup).
+type RunRepositoryOrigin struct {
+	RepositoryName         string `json:"repositoryName"`
+	RepositoryLocationName string `json:"repositoryLocationName"`
+}
+
+type Run struct {
+	RunId            string               `json:"runId"`
+	JobName          string               `json:"jobName"`
+	Status           string               `json:"status"`
+	CreationTime     float64              `json:"creationTime"`
+	UpdateTime       float64              `json:"updateTime"`
+	EndTime          float64              `json:"endTime"`
+	RepositoryOrigin *RunRepositoryOrigin `json:"repositoryOrigin"`
+}
+
 type GraphQLRunsResponse struct {
 	Data struct {
 		RunsOrError struct {
-			Typename string `json:"__typename"`
-			Results    []struct {
-				RunId            string  `json:"runId"`
-				JobName          string  `json:"jobName"`
-				Status           string  `json:"status"`
-				CreationTime     float64 `json:"creationTime"`
-				UpdateTime       float64 `json:"updateTime"`
-				EndTime          float64 `json:"endTime"`
-				RepositoryOrigin *struct {
-					RepositoryName         string `json:"repositoryName"`
-					RepositoryLocationName string `json:"repositoryLocationName"`
-				} `json:"repositoryOrigin"`
-			} `json:"results"`
-			Message string   `json:"message"`
-			Stack   []string `json:"stack"`
+			Typename string   `json:"__typename"`
+			Results  []Run    `json:"results"`
+			Message  string   `json:"message"`
+			Stack    []string `json:"stack"`
 		} `json:"runsOrError"`
 	} `json:"data"`
 	Errors []struct {
@@ -43,19 +49,55 @@ type GraphQLRunsResponse struct {
 //go:embed queries/get_runs.graphql
 var runsQuery string
 
-func getRunsRequest(statuses []string, updateAfter float64) *GraphQLRequest {
+func getRunsRequest(statuses []string, updateAfter float64, cursor string, limit int) *GraphQLRequest {
 
 	var updatedAfter interface{} = updateAfter
 	if updateAfter == 0.0 {
 		updatedAfter = nil
 	}
+	var cursorVar interface{} = cursor
+	if cursor == "" {
+		cursorVar = nil
+	}
 	variables := map[string]interface{}{
 		"statuses":     statuses,
 		"updatedAfter": updatedAfter,
+		"cursor":       cursorVar,
+		"limit":        limit,
 	}
 	return &GraphQLRequest{
 		Query:     runsQuery,
 		Variables: variables,
+	}
+}
+
+// fetchRunPages fetches every run matching statuses/updateAfter, paging
+// through runsOrError via cursor and invoking onPage once per page, instead
+// of accumulating every run into memory before returning. The caller is
+// expected to fold each page into its own (much smaller) aggregate state.
+//
+// The cursor Dagster expects is simply the runId of the last run already
+// seen (not an opaque token) — see
+// https://github.com/dagster-io/dagster/issues/31024#issuecomment-5126177124.
+func fetchRunPages(ctx context.Context, statuses []string, updateAfter float64, dagsterGraphQLEndpoint string, pageSize int, onPage func([]Run) error) error {
+	cursor := ""
+
+	for {
+		req := getRunsRequest(statuses, updateAfter, cursor, pageSize)
+		resp, err := getRuns(ctx, req, dagsterGraphQLEndpoint)
+		if err != nil {
+			return err
+		}
+
+		results := resp.Data.RunsOrError.Results
+		if err := onPage(results); err != nil {
+			return err
+		}
+
+		if len(results) < pageSize {
+			return nil
+		}
+		cursor = results[len(results)-1].RunId
 	}
 }
 

--- a/internal/collector/graphql_test.go
+++ b/internal/collector/graphql_test.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,24 +17,30 @@ func TestGetRunsRequest(t *testing.T) {
 	tests := []struct {
 		statuses             []string
 		updatedAfter         float64
+		cursor               string
+		limit                int
 		expectedUpdatedAfter float64
 	}{
 		{
 			statuses:             []string{"SUCCESS", "FAILED"},
 			updatedAfter:         1000000,
+			cursor:               "run_abc",
+			limit:                500,
 			expectedUpdatedAfter: 1000000,
 		},
 	}
 
 	for _, tc := range tests {
-		req := getRunsRequest(tc.statuses, tc.updatedAfter)
+		req := getRunsRequest(tc.statuses, tc.updatedAfter, tc.cursor, tc.limit)
 		assert.Equal(t, req.Variables["statuses"], tc.statuses)
 		assert.Equal(t, req.Variables["updatedAfter"], tc.expectedUpdatedAfter)
+		assert.Equal(t, req.Variables["cursor"], tc.cursor)
+		assert.Equal(t, req.Variables["limit"], tc.limit)
 		assert.Contains(t, req.Query, "query")
 	}
 }
 
-func TestGetRunsRequestWithNilUpdatedAfter(t *testing.T) {
+func TestGetRunsRequestWithNilUpdatedAfterAndCursor(t *testing.T) {
 	tests := []struct {
 		statuses     []string
 		updatedAfter float64
@@ -45,9 +52,10 @@ func TestGetRunsRequestWithNilUpdatedAfter(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		req := getRunsRequest(tc.statuses, tc.updatedAfter)
+		req := getRunsRequest(tc.statuses, tc.updatedAfter, "", 500)
 		assert.Equal(t, req.Variables["statuses"], tc.statuses)
 		assert.Nil(t, req.Variables["updatedAfter"])
+		assert.Nil(t, req.Variables["cursor"])
 		assert.Contains(t, req.Query, "query")
 	}
 }
@@ -62,18 +70,7 @@ func TestGetRuns(t *testing.T) {
 		}
 		mockResp := GraphQLRunsResponse{}
 		mockResp.Data.RunsOrError.Typename = "Runs"
-		mockResp.Data.RunsOrError.Results = []struct {
-			RunId            string  `json:"runId"`
-			JobName          string  `json:"jobName"`
-			Status           string  `json:"status"`
-			CreationTime     float64 `json:"creationTime"`
-			UpdateTime       float64 `json:"updateTime"`
-			EndTime          float64 `json:"endTime"`
-			RepositoryOrigin *struct {
-				RepositoryName         string `json:"repositoryName"`
-				RepositoryLocationName string `json:"repositoryLocationName"`
-			} `json:"repositoryOrigin"`
-		}{
+		mockResp.Data.RunsOrError.Results = []Run{
 			{
 				RunId:        "run_123",
 				JobName:      "test_job",
@@ -81,10 +78,7 @@ func TestGetRuns(t *testing.T) {
 				CreationTime: 1710000000.0,
 				UpdateTime:   1720000000.0,
 				EndTime:      1730000000.0,
-				RepositoryOrigin: &struct {
-					RepositoryName         string `json:"repositoryName"`
-					RepositoryLocationName string `json:"repositoryLocationName"`
-				}{
+				RepositoryOrigin: &RunRepositoryOrigin{
 					RepositoryName:         "__repository__",
 					RepositoryLocationName: "test_location",
 				},
@@ -99,7 +93,7 @@ func TestGetRuns(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	req := getRunsRequest([]string{"STARTED"}, 0.0)
+	req := getRunsRequest([]string{"STARTED"}, 0.0, "", 500)
 
 	resp, err := getRuns(t.Context(), req, ts.URL)
 
@@ -132,7 +126,7 @@ func TestGetRunsRespectsContextTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer cancel()
 
-	req := getRunsRequest(nil, 0.0)
+	req := getRunsRequest(nil, 0.0, "", 500)
 
 	start := time.Now()
 	_, err := getRuns(ctx, req, ts.URL)
@@ -148,9 +142,64 @@ func TestGetRunsWithServerError(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	req := getRunsRequest(nil, 0.0)
+	req := getRunsRequest(nil, 0.0, "", 500)
 	response, err := getRuns(t.Context(), req, ts.URL)
 
 	assert.Error(t, err)
 	assert.Nil(t, response)
+}
+
+// makeRunsPage builds n runs named run_<offset>..run_<offset+n-1>, for use
+// as a canned page of results in the fake server below.
+func makeRunsPage(offset, n int) []Run {
+	runs := make([]Run, n)
+	for i := range n {
+		runs[i] = Run{RunId: fmt.Sprintf("run_%d", offset+i), JobName: "job_a", Status: "SUCCESS"}
+	}
+	return runs
+}
+
+func TestFetchRunPagesPaginatesUntilAShortPage(t *testing.T) {
+	const pageSize = 3
+	pages := [][]Run{
+		makeRunsPage(0, pageSize), // full page: expect another request
+		makeRunsPage(3, pageSize), // full page: expect another request
+		makeRunsPage(6, 1),        // short page: this must be the last request
+	}
+
+	var seenCursors []string
+	call := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if cursor, ok := req.Variables["cursor"]; ok && cursor != nil {
+			seenCursors = append(seenCursors, cursor.(string))
+		} else {
+			seenCursors = append(seenCursors, "")
+		}
+
+		require.Less(t, call, len(pages), "fetchRunPages made more requests than expected")
+		mockResp := GraphQLRunsResponse{}
+		mockResp.Data.RunsOrError.Typename = "Runs"
+		mockResp.Data.RunsOrError.Results = pages[call]
+		call++
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(mockResp))
+	}))
+	defer ts.Close()
+
+	var got []Run
+	err := fetchRunPages(t.Context(), []string{"SUCCESS"}, 0, ts.URL, pageSize, func(page []Run) error {
+		got = append(got, page...)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, call, "expected exactly 3 page requests (2 full pages + 1 short page)")
+	assert.Len(t, got, 7)
+	assert.Equal(t, []string{"", "run_2", "run_5"}, seenCursors,
+		"each page's cursor should be the runId of the previous page's last result")
 }

--- a/internal/collector/queries/get_runs.graphql
+++ b/internal/collector/queries/get_runs.graphql
@@ -1,5 +1,5 @@
-query GetRuns($statuses: [RunStatus!], $updatedAfter: Float) {
-  runsOrError(filter: { statuses: $statuses, updatedAfter: $updatedAfter }) {
+query GetRuns($statuses: [RunStatus!], $updatedAfter: Float, $cursor: String, $limit: Int) {
+  runsOrError(filter: { statuses: $statuses, updatedAfter: $updatedAfter }, cursor: $cursor, limit: $limit) {
     __typename
     ... on Runs {
       results {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,16 +34,6 @@ func Load() (*Config, error) {
 		dagsterGraphQLEndpoint = "http://127.0.0.1:3000/graphql"
 	}
 
-	cacheTTLMinutes := 24 * 60
-	if ttl_str := os.Getenv("CACHE_TTL_MINUTES"); ttl_str != "" {
-		ttl, err := strconv.Atoi(ttl_str)
-		if err != nil {
-			return nil, fmt.Errorf("invalid Cache TTL Minutes value: %w", err)
-		}
-		cacheTTLMinutes = ttl
-	}
-	cacheTTL := time.Duration(cacheTTLMinutes) * time.Minute
-
 	dagsterScrapingIntervalSeconds := 15
 	if scrapingInterval_str := os.Getenv("DAGSTER_SCRAPING_INTERVAL_SECONDS"); scrapingInterval_str != "" {
 		scrapingInterval, err := strconv.Atoi(scrapingInterval_str)
@@ -53,6 +43,33 @@ func Load() (*Config, error) {
 		dagsterScrapingIntervalSeconds = scrapingInterval
 	}
 	dagsterScrapingInterval := time.Duration(dagsterScrapingIntervalSeconds) * time.Second
+
+	runsUpdatedAfterSafetyMarginMinutes := 5
+	if margin_str := os.Getenv("RUNS_UPDATED_AFTER_SAFETY_MARGIN_MINUTES"); margin_str != "" {
+		margin, err := strconv.Atoi(margin_str)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Runs Updated After Safety Margin Minutes value: %w", err)
+		}
+		runsUpdatedAfterSafetyMarginMinutes = margin
+	}
+	runsUpdatedAfterSafetyMargin := time.Duration(runsUpdatedAfterSafetyMarginMinutes) * time.Minute
+
+	// processedRuns entries are touched (their TTL refreshed) on every
+	// scrape that still finds a run relevant, so the TTL only needs to
+	// survive consecutive missed/failed scrapes rather than any particular
+	// data-related window. Defaulting it to a multiple of the scraping
+	// interval — rather than an unrelated fixed value — means it tolerates
+	// about the same span as runsUpdatedAfterSafetyMargin's default (20 x
+	// 15s = 5m) worth of scrape failures before risking a double count.
+	const cacheTTLScrapingIntervalMultiplier = 20
+	cacheTTL := cacheTTLScrapingIntervalMultiplier * dagsterScrapingInterval
+	if ttl_str := os.Getenv("CACHE_TTL_MINUTES"); ttl_str != "" {
+		ttl, err := strconv.Atoi(ttl_str)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Cache TTL Minutes value: %w", err)
+		}
+		cacheTTL = time.Duration(ttl) * time.Minute
+	}
 
 	// Completed runs are fetched incrementally after the first scrape (see
 	// CollectCompletedRuns), so LookbackWindow only matters for the initial
@@ -75,16 +92,6 @@ func Load() (*Config, error) {
 		}
 		runsPageSize = pageSize
 	}
-
-	runsUpdatedAfterSafetyMarginMinutes := 5
-	if margin_str := os.Getenv("RUNS_UPDATED_AFTER_SAFETY_MARGIN_MINUTES"); margin_str != "" {
-		margin, err := strconv.Atoi(margin_str)
-		if err != nil {
-			return nil, fmt.Errorf("invalid Runs Updated After Safety Margin Minutes value: %w", err)
-		}
-		runsUpdatedAfterSafetyMarginMinutes = margin
-	}
-	runsUpdatedAfterSafetyMargin := time.Duration(runsUpdatedAfterSafetyMarginMinutes) * time.Minute
 
 	dagsterScrapingTimeoutSeconds := 10
 	if scrapingTimeout_str := os.Getenv("DAGSTER_SCRAPING_TIMEOUT_SECONDS"); scrapingTimeout_str != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,12 +8,14 @@ import (
 )
 
 type Config struct {
-	Port                    int
-	DagsterGraphQLEndpoint  string
-	LookbackWindow          time.Duration
-	CacheTTL                time.Duration
-	DagsterScrapingInterval time.Duration
-	DagsterScrapingTimeout  time.Duration
+	Port                         int
+	DagsterGraphQLEndpoint       string
+	LookbackWindow               time.Duration
+	CacheTTL                     time.Duration
+	DagsterScrapingInterval      time.Duration
+	DagsterScrapingTimeout       time.Duration
+	RunsPageSize                 int
+	RunsUpdatedAfterSafetyMargin time.Duration
 }
 
 // Load は環境変数などから設定を読み込んで返す
@@ -31,16 +33,6 @@ func Load() (*Config, error) {
 	if dagsterGraphQLEndpoint == "" {
 		dagsterGraphQLEndpoint = "http://127.0.0.1:3000/graphql"
 	}
-
-	lookbackWindowMinutes := 12 * 60
-	if lookback_window_str := os.Getenv("LOOKBACK_WINDOW_MINUTES"); lookback_window_str != "" {
-		lookback, err := strconv.Atoi(lookback_window_str)
-		if err != nil {
-			return nil, fmt.Errorf("invalid Lookback Window Minutes value: %w", err)
-		}
-		lookbackWindowMinutes = lookback
-	}
-	lookbackWindow := time.Duration(lookbackWindowMinutes) * time.Minute
 
 	cacheTTLMinutes := 24 * 60
 	if ttl_str := os.Getenv("CACHE_TTL_MINUTES"); ttl_str != "" {
@@ -62,12 +54,56 @@ func Load() (*Config, error) {
 	}
 	dagsterScrapingInterval := time.Duration(dagsterScrapingIntervalSeconds) * time.Second
 
+	// Completed runs are fetched incrementally after the first scrape (see
+	// CollectCompletedRuns), so LookbackWindow only matters for the initial
+	// backfill on startup. Defaulting it to the scraping interval avoids
+	// dumping a large batch of historical runs into the counters at t=0.
+	lookbackWindow := dagsterScrapingInterval
+	if lookback_window_str := os.Getenv("LOOKBACK_WINDOW_MINUTES"); lookback_window_str != "" {
+		lookback, err := strconv.Atoi(lookback_window_str)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Lookback Window Minutes value: %w", err)
+		}
+		lookbackWindow = time.Duration(lookback) * time.Minute
+	}
+
+	runsPageSize := 500
+	if pageSize_str := os.Getenv("RUNS_PAGE_SIZE"); pageSize_str != "" {
+		pageSize, err := strconv.Atoi(pageSize_str)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Runs Page Size value: %w", err)
+		}
+		runsPageSize = pageSize
+	}
+
+	runsUpdatedAfterSafetyMarginMinutes := 5
+	if margin_str := os.Getenv("RUNS_UPDATED_AFTER_SAFETY_MARGIN_MINUTES"); margin_str != "" {
+		margin, err := strconv.Atoi(margin_str)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Runs Updated After Safety Margin Minutes value: %w", err)
+		}
+		runsUpdatedAfterSafetyMarginMinutes = margin
+	}
+	runsUpdatedAfterSafetyMargin := time.Duration(runsUpdatedAfterSafetyMarginMinutes) * time.Minute
+
+	dagsterScrapingTimeoutSeconds := 10
+	if scrapingTimeout_str := os.Getenv("DAGSTER_SCRAPING_TIMEOUT_SECONDS"); scrapingTimeout_str != "" {
+		scrapingTimeout, err := strconv.Atoi(scrapingTimeout_str)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Dagster Scraping Timeout Seconds value: %w", err)
+		}
+		dagsterScrapingTimeoutSeconds = scrapingTimeout
+	}
+	dagsterScrapingTimeout := time.Duration(dagsterScrapingTimeoutSeconds) * time.Second
+
 	return &Config{
-		Port:                    port,
-		DagsterGraphQLEndpoint:  dagsterGraphQLEndpoint,
-		LookbackWindow:          lookbackWindow,
-		CacheTTL:                cacheTTL,
-		DagsterScrapingInterval: dagsterScrapingInterval,
-		DagsterScrapingTimeout:  10 * time.Second,
+		Port:                         port,
+		DagsterGraphQLEndpoint:       dagsterGraphQLEndpoint,
+		LookbackWindow:               lookbackWindow,
+		CacheTTL:                     cacheTTL,
+		DagsterScrapingInterval:      dagsterScrapingInterval,
+		DagsterScrapingTimeout:       dagsterScrapingTimeout,
+		RunsPageSize:                 runsPageSize,
+		RunsUpdatedAfterSafetyMargin: runsUpdatedAfterSafetyMargin,
 	}, nil
 }

--- a/internal/server/scrape_test.go
+++ b/internal/server/scrape_test.go
@@ -23,7 +23,7 @@ func TestScrapeDagsterHonorsContextTimeoutWhenRunningConcurrently(t *testing.T) 
 	defer ts.Close()
 	defer close(unblock)
 
-	c := collector.NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour)
+	c := collector.NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 
 	const ctxTimeout = 50 * time.Millisecond
 	ctx, cancel := context.WithTimeout(t.Context(), ctxTimeout)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,7 +15,7 @@ import (
 
 func RunServer(ctx context.Context, config *config.Config) {
 	portSuffix := fmt.Sprintf(":%d", config.Port)
-	c := collector.NewDagsterCollector(ctx, config.DagsterGraphQLEndpoint, config.LookbackWindow, config.CacheTTL)
+	c := collector.NewDagsterCollector(ctx, config.DagsterGraphQLEndpoint, config.LookbackWindow, config.CacheTTL, config.RunsPageSize, config.RunsUpdatedAfterSafetyMargin)
 	prometheus.MustRegister(c)
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
## What

- `CollectCompletedRuns` now fetches incrementally: after the first scrape (which backfills `LOOKBACK_WINDOW_MINUTES`), it only asks for runs updated since a tracked watermark (max `updateTime` seen), minus a small safety margin.
- `LOOKBACK_WINDOW_MINUTES` now defaults to the scraping interval instead of 12h, since it's only used for the initial backfill.
- Both `CollectActiveRuns` and `CollectCompletedRuns` page through `runsOrError` via cursor (`RUNS_PAGE_SIZE`, default 500), streaming each page into the caller's aggregate state instead of buffering the full result set in memory.
- New env vars: `RUNS_PAGE_SIZE`, `RUNS_UPDATED_AFTER_SAFETY_MARGIN_MINUTES`, `DAGSTER_SCRAPING_TIMEOUT_SECONDS` (previously hardcoded to 10s).

## Why

The exporter was re-fetching the entire lookback window's worth of completed runs on every single scrape (every 15s by default), even though almost all of it had already been seen moments earlier — wasteful regardless of pagination. Separately, run volume growing over time was a real memory concern; naively paginating by accumulating every page into one slice before returning doesn't actually bound memory, so `fetchRunPages` streams page-by-page instead.

The GraphQL `cursor` argument is undocumented upstream (dagster-io/dagster#31024) — confirmed via the actual `dagster`/`dagster_graphql` source that it's simply the `runId` of the last run already seen, not an opaque token.

## QA

- New tests: `TestFetchRunPagesPaginatesUntilAShortPage` (cursor progression), `TestCollectCompletedRunsUsesIncrementalUpdatedAfter` (watermark behavior across two scrapes).
- `go test -race ./...` passes.
- Verified against a real local Dagster instance: default (short lookback) shows no stale backfill; `LOOKBACK_WINDOW_MINUTES=1440` correctly backfills historical completed runs.

## Ref

Addresses the scraping-optimization item in TODO.md (not committed).