### PR TITLE
Add GHCR publish workflow on version tag push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,48 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/exporter.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What

Adds `.github/workflows/docker-publish.yml`. On a `v*.*.*` tag push, it builds `docker/exporter.Dockerfile` for `linux/amd64` and `linux/arm64` and pushes the image to `ghcr.io/hirofumitsuda/dagster-prometheus-exporter`. Auth uses the built-in `GITHUB_TOKEN`, so no extra secrets are needed. Images are tagged with semver (`x.y.z`, `x.y`) plus `latest`.

## Why

Addresses the TODO.md item "cut the first release tag and publish the Docker image to a registry". This lets other developers `docker pull` the image directly (e.g. for a Kubernetes Deployment) instead of building it themselves.

## QA

- [ ] Merge to `main`
- [ ] Push a tag (e.g. `v0.1.0`) and confirm the workflow builds and pushes successfully
- [ ] After the first publish, set the GHCR package visibility to Public in the repo's package settings (GHCR creates new packages as Private by default)
- [ ] `docker pull ghcr.io/hirofumitsuda/dagster-prometheus-exporter:v0.1.0` and run it locally to confirm the image works

## Ref

N/A