### PR TITLE
Add release badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # dagster-prometheus-exporter
 
+[![Release](https://img.shields.io/github/v/release/HirofumiTsuda/dagster-prometheus-exporter)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/releases/latest)
 [![CI](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml)
 [![Go version](https://img.shields.io/github/go-mod/go-version/HirofumiTsuda/dagster-prometheus-exporter)](go.mod)


### PR DESCRIPTION
## What

Adds a `Release` badge (`img.shields.io/github/v/release/...`) to the top of README.md, linking to the repo's Releases page.

## Why

The `v0.1.0` release was just published (with the Docker image on GHCR), so the README should surface the current release version instead of only linking to CI/CodeQL/Go version/License.

## QA

- [x] Verified the badge URL resolves (`curl -I` returns 200)
- [ ] Visual check that the badge renders correctly on GitHub

## Ref

Follow-up to the `v0.1.0` release: https://github.com/HirofumiTsuda/dagster-prometheus-exporter/releases/tag/v0.1.0