### PR TITLE
Document GHCR image and mark tagged release done in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,13 @@ go build -o exporter ./cmd/exporter
 DAGSTER_GRAPHQL_ENDPOINT=http://localhost:3000/graphql ./exporter
 ```
 
-Or with Docker:
+Or pull the published image from GHCR:
+
+```sh
+docker run -p 9101:9101 -e DAGSTER_GRAPHQL_ENDPOINT=http://dagster:3000/graphql ghcr.io/hirofumitsuda/dagster-prometheus-exporter:latest
+```
+
+Or build it yourself:
 
 ```sh
 docker build -f docker/exporter.Dockerfile -t dagster-prometheus-exporter .
@@ -193,7 +199,7 @@ CI (`.github/workflows/ci.yml`) runs all of the above on every push and pull req
 - [ ] Exporter self-health metrics (scrape duration/errors)
 - [ ] Schedule tick status
 - [ ] Sensor / asset materialization metrics
-- [ ] Published container image / tagged release
+- [x] Published container image / tagged release
 
 ## License
 


### PR DESCRIPTION
## What

- Add a `docker run` snippet in Usage that pulls the published image from `ghcr.io/hirofumitsuda/dagster-prometheus-exporter:latest`, ahead of the "build it yourself" instructions.
- Check off "Published container image / tagged release" in the Roadmap.

## Why

`v0.1.0` has been tagged and the `Docker Publish` workflow successfully pushed the image to GHCR, so the README should point users at the published image instead of only documenting a local build, and the roadmap should reflect that this item is done.

## QA

- Confirmed the `v0.1.0` release exists (`gh release list`) and the `Docker Publish` workflow run for that tag succeeded, pushing `ghcr.io/hirofumitsuda/dagster-prometheus-exporter` with `latest`/semver tags.
- Visual diff review of README changes only; no code changes.

## Ref