### PR TITLE
Add CONTRIBUTING.md and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a problem with the exporter
+title: ""
+labels: bug
+---
+
+## Description
+
+What happened, and what did you expect instead?
+
+## Steps to reproduce
+
+## Environment
+
+- Exporter version / image tag:
+- Dagster version:
+- Deployment (Docker / Kubernetes / binary):
+
+## Logs / metrics output
+
+Relevant log output, or the `/metrics` output for the affected series.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest a new metric or capability for the exporter
+title: ""
+labels: enhancement
+---
+
+## Problem
+
+What are you trying to observe or do that the exporter doesn't currently support?
+
+## Proposed solution
+
+Metric name(s)/labels, or the behavior you'd like to see, if you have a concrete idea.
+
+## Alternatives considered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Reporting bugs / requesting features
+
+Open a [GitHub issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose) using the appropriate template.
+
+## Submitting a pull request
+
+1. Fork the repo and create a branch from `main`.
+2. Make your change.
+3. Run the checks below locally and make sure they pass.
+4. Open a pull request against `main` and fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md) (`What` / `Why` / `QA` / `Ref`). Link any related issue in the `Ref` section (e.g. `Closes #26`).
+
+CI (`.github/workflows/ci.yml`) runs the same checks on every push and pull request, plus CodeQL static analysis.
+
+## Running checks locally
+
+```sh
+go build ./...
+go vet ./...
+golangci-lint run ./...
+go test ./...
+```
+
+## Local development stack
+
+`docker compose up --build` brings up a full stack — a `dagster dev` instance with sample jobs, this exporter, Prometheus, and Grafana — so you can test changes against a real Dagster instance. See [Quick Start](README.md#quick-start) in the README for details.


### PR DESCRIPTION
## What

Add a `CONTRIBUTING.md` describing how to submit a PR and run checks locally, plus `.github/ISSUE_TEMPLATE/` with a bug report and a feature request template.

## Why

Standard OSS hygiene for a public repo: gives contributors a single place for the PR/testing workflow, and a consistent starting point for bug reports and feature requests instead of a blank issue body.

## QA

Reviewed the rendered Markdown/YAML frontmatter locally; no code changes, so no build/test impact.

## Ref

Closes #26
Closes #27