### PR TITLE
Add test coverage measurement via Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,12 @@ jobs:
 
       - run: go vet ./...
 
-      - run: go test -race ./...
+      - run: go test -race -coverprofile=coverage.txt ./...
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     needs: changes

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Release](https://img.shields.io/github/v/release/HirofumiTsuda/dagster-prometheus-exporter)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/releases/latest)
 [![CI](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/HirofumiTsuda/dagster-prometheus-exporter/graph/badge.svg)](https://codecov.io/gh/HirofumiTsuda/dagster-prometheus-exporter)
 [![CodeQL](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml)
 [![Go version](https://img.shields.io/github/go-mod/go-version/HirofumiTsuda/dagster-prometheus-exporter)](go.mod)
 [![License: MIT](https://img.shields.io/github/license/HirofumiTsuda/dagster-prometheus-exporter)](LICENSE)


### PR DESCRIPTION
## What

Add `-coverprofile=coverage.txt` to the `go test -race` step in CI, and upload the result to Codecov via `codecov/codecov-action@v5`. Also adds a Codecov badge to the README.

## Why

Track test coverage over time and surface where it's thin — `internal/server` and `cmd/exporter` currently look under-covered (47.7% and 0% respectively) compared to `internal/collector` (72.6%). No `-covermode` flag is needed: Go defaults it to `atomic` automatically whenever `-race` is set.

## QA

- Ran `go test -race -coverprofile=coverage.txt ./...` locally; passes and produces a valid coverage report (`cmd/exporter` 0.0%, `internal/collector` 72.6%, `internal/config` 0.0%, `internal/server` 47.7%).
- Validated `.github/workflows/ci.yml` YAML with `python3 -c "import yaml; yaml.safe_load(...)"`.
- `CODECOV_TOKEN` has already been set as a repo secret.

## Ref

Closes #32