### PR TITLE
Pin dev-stack Dagster version and document compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Prometheus exporter for [Dagster](https://dagster.io/) run metrics. It polls D
 ## Table of Contents
 
 - [Quick Start](#quick-start)
+- [Compatibility](#compatibility)
 - [Motivation](#motivation)
 - [Architecture](#architecture)
 - [Metrics](#metrics)
@@ -37,6 +38,10 @@ docker compose up --build
 | Exporter metrics | http://localhost:9101/metrics | |
 | Prometheus | http://localhost:9090 | Scrapes the exporter using `dev/prometheus/prometheus.docker.yml`. |
 | Grafana | http://localhost:3001 | Login `root` / `passw0rd` (local dev only). Dashboard "Dagster Run Monitoring" is auto-provisioned from `dev/grafana/dashboards/dagster-dashboard.json`. |
+
+## Compatibility
+
+Tested against Dagster **1.13.15** (the version pinned in `pyproject.toml`/`uv.lock` for the local dev stack). Dagster's GraphQL API isn't a stable, versioned contract — fields and types can change between releases — so this exporter isn't guaranteed to work against significantly older or newer Dagster versions. If you hit a GraphQL error running against a different version, please [open an issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose).
 
 ## Motivation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "A python environment used for tests"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "dagster>=1.13.15",
-    "dagster-webserver>=1.13.15",
+    "dagster>=1.13.15,<1.14",
+    "dagster-webserver>=1.13.15,<1.14",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -238,8 +238,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dagster", specifier = ">=1.13.15" },
-    { name = "dagster-webserver", specifier = ">=1.13.15" },
+    { name = "dagster", specifier = ">=1.13.15,<1.14" },
+    { name = "dagster-webserver", specifier = ">=1.13.15,<1.14" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Add a `Compatibility` section to the README documenting the tested Dagster version (`1.13.15`).
- Tighten `pyproject.toml`'s `dagster`/`dagster-webserver` constraints from `>=1.13.15` to `>=1.13.15,<1.14`, and re-lock with `uv lock`.

## Why

The GraphQL queries in `internal/collector` are written against a specific Dagster GraphQL schema, which isn't a stable, versioned contract across Dagster releases. An unbounded `>=1.13.15` constraint means a future `uv sync` could silently pull in a newer, incompatible Dagster for the dev stack. Pinning the upper bound keeps the dev stack on a known-good range, and the README note sets expectations for anyone running this against a different Dagster version.

A deeper investigation into exactly which Dagster version range is actually compatible is tracked separately as follow-up work (not part of this PR).

## QA

- `uv lock` re-resolved cleanly; the locked `dagster`/`dagster-webserver` package versions are unchanged (`1.13.15`), only the recorded constraint in `uv.lock` changed.
- Reviewed the rendered README section.

## Ref

None