### PR TITLE
Add exporter self-health metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ All metrics are labeled with `job_name` and `location` (the Dagster code locatio
 | `dagster_completed_runs_total` | Counter | `job_name`, `location`, `status` | Total number of completed runs (`success`, `failure`) per job, since the exporter started. Jobs that have never run are seeded at `0`. Series for jobs that no longer exist in Dagster are deleted automatically. |
 | `dagster_last_run_info` | Gauge | `job_name`, `location`, `status` | Always `1`; an "info" metric (same pattern as `kube_pod_info`) reporting the status of the most recently completed run per job. Kept until a newer completion supersedes it or the job is removed from Dagster — it does not disappear just because nothing has completed recently. Use the `status` label to tell success from failure, e.g. in a Grafana table panel. |
 
+### Exporter self-health
+
+These report on the exporter itself — whether its own scrapes of Dagster are succeeding — rather than on Dagster's run state. All three are labeled `collector`, one of `job_locations`, `active_runs`, or `completed_runs` (the three concurrent collectors described in [Architecture](#architecture)).
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `dagster_exporter_scrape_duration_seconds` | Gauge | `collector` | Duration of that collector's most recent scrape. |
+| `dagster_exporter_last_scrape_success` | Gauge | `collector` | `1` if that collector's most recent scrape succeeded, `0` if it failed. |
+| `dagster_exporter_scrape_errors_total` | Counter | `collector` | Total number of failed scrapes for that collector, since the exporter started. |
+
 ### Example output
 
 ```

--- a/internal/collector/active_runs.go
+++ b/internal/collector/active_runs.go
@@ -18,7 +18,7 @@ type ActiveRunKey struct {
 	Status       string
 }
 
-func CollectActiveRuns(ctx context.Context, c *DagsterCollector) {
+func CollectActiveRuns(ctx context.Context, c *DagsterCollector) error {
 	counts := make(map[ActiveRunKey]int)
 
 	err := fetchRunPages(ctx, activeStatuses, 0, c.dagsterGraphQLEndpoint, c.runsPageSize, func(page []Run) error {
@@ -38,7 +38,7 @@ func CollectActiveRuns(ctx context.Context, c *DagsterCollector) {
 	})
 	if err != nil {
 		log.Printf("failed to collect active runs from dagster: %v", err)
-		return
+		return err
 	}
 
 	c.mutex.Lock()
@@ -58,6 +58,7 @@ func CollectActiveRuns(ctx context.Context, c *DagsterCollector) {
 	}
 
 	c.activeRunsCounts = counts
+	return nil
 }
 
 func reflectActiveRuns(c *DagsterCollector, ch chan<- prometheus.Metric) {

--- a/internal/collector/active_runs_test.go
+++ b/internal/collector/active_runs_test.go
@@ -31,7 +31,7 @@ func TestCollectActiveRunsLocationLabel(t *testing.T) {
 	defer ts.Close()
 
 	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
-	CollectActiveRuns(t.Context(), c)
+	assert.NoError(t, CollectActiveRuns(t.Context(), c))
 
 	assert.Equal(t, 1, c.activeRunsCounts[ActiveRunKey{JobName: "job_a", LocationName: "loc_a", Status: "STARTED"}])
 	assert.Equal(t, 1, c.activeRunsCounts[ActiveRunKey{JobName: "job_b", LocationName: unknownLocationName, Status: "QUEUED"}])
@@ -60,7 +60,7 @@ func TestCollectActiveRunsZeroFillsKnownJobs(t *testing.T) {
 		{JobName: "never_run_job", LocationName: "loc_a"}: {},
 	}
 
-	CollectActiveRuns(t.Context(), c)
+	assert.NoError(t, CollectActiveRuns(t.Context(), c))
 
 	for _, status := range activeStatuses {
 		assert.Equal(t, 0, c.activeRunsCounts[ActiveRunKey{JobName: "never_run_job", LocationName: "loc_a", Status: status}])

--- a/internal/collector/active_runs_test.go
+++ b/internal/collector/active_runs_test.go
@@ -66,3 +66,14 @@ func TestCollectActiveRunsZeroFillsKnownJobs(t *testing.T) {
 		assert.Equal(t, 0, c.activeRunsCounts[ActiveRunKey{JobName: "never_run_job", LocationName: "loc_a", Status: status}])
 	}
 }
+
+func TestCollectActiveRunsReturnsErrorOnServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	assert.Error(t, CollectActiveRuns(t.Context(), c))
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -14,19 +14,24 @@ const unknownLocationName = "unknown"
 type DagsterCollector struct {
 	dagsterGraphQLEndpoint string
 
-	activeRunsDesc       *prometheus.Desc
-	completedRunsCounter *prometheus.CounterVec
-	lastRunStatusDesc    *prometheus.Desc
+	activeRunsDesc        *prometheus.Desc
+	completedRunsCounter  *prometheus.CounterVec
+	lastRunStatusDesc     *prometheus.Desc
+	scrapeDurationDesc    *prometheus.Desc
+	lastScrapeSuccessDesc *prometheus.Desc
+	scrapeErrorsCounter   *prometheus.CounterVec
 
-	mutex                        sync.Mutex
-	activeRunsCounts             map[ActiveRunKey]int
-	processedRuns                *ttlcache.Cache[string, struct{}]
-	lookbackWindow               time.Duration
-	knownJobs                    map[JobKey]struct{}
-	lastRunStatus                map[JobKey]lastRunEntry
-	trackedCompletedRunKeys      map[JobKey]struct{}
-	lastSeenUpdateTime           float64
-	runsPageSize                 int
+	mutex                   sync.Mutex
+	activeRunsCounts        map[ActiveRunKey]int
+	processedRuns           *ttlcache.Cache[string, struct{}]
+	lookbackWindow          time.Duration
+	knownJobs               map[JobKey]struct{}
+	lastRunStatus           map[JobKey]lastRunEntry
+	trackedCompletedRunKeys map[JobKey]struct{}
+	lastSeenUpdateTime      float64
+	runsPageSize            int
+	scrapeDuration          map[string]float64
+	lastScrapeSuccess       map[string]bool
 	// runsUpdatedAfterSafetyMargin is subtracted from the last-seen
 	// updateTime watermark before it's used as the next scrape's
 	// updatedAfter. A run's updateTime can be set slightly before its write
@@ -77,23 +82,49 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"job_name", "location", "status"},
 			nil,
 		),
+		scrapeDurationDesc: prometheus.NewDesc(
+			"dagster_exporter_scrape_duration_seconds",
+			"Duration of the most recent scrape, per collector",
+			[]string{"collector"},
+			nil,
+		),
+		lastScrapeSuccessDesc: prometheus.NewDesc(
+			"dagster_exporter_last_scrape_success",
+			"Whether the most recent scrape succeeded (1) or failed (0), per collector",
+			[]string{"collector"},
+			nil,
+		),
+		scrapeErrorsCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "dagster_exporter_scrape_errors_total",
+				Help: "Total number of failed scrapes, per collector",
+			},
+			[]string{"collector"},
+		),
 		processedRuns:                cache,
 		lookbackWindow:               lookbackWindow,
 		lastRunStatus:                make(map[JobKey]lastRunEntry),
 		trackedCompletedRunKeys:      make(map[JobKey]struct{}),
 		runsPageSize:                 runsPageSize,
 		runsUpdatedAfterSafetyMargin: runsUpdatedAfterSafetyMargin,
+		scrapeDuration:               make(map[string]float64),
+		lastScrapeSuccess:            make(map[string]bool),
 	}
 }
 
 func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.activeRunsDesc
 	ch <- c.lastRunStatusDesc
+	ch <- c.scrapeDurationDesc
+	ch <- c.lastScrapeSuccessDesc
 	c.completedRunsCounter.Describe(ch)
+	c.scrapeErrorsCounter.Describe(ch)
 }
 
 func (c *DagsterCollector) Collect(ch chan<- prometheus.Metric) {
 	reflectActiveRuns(c, ch)
 	reflectLastRunStatus(c, ch)
+	reflectScrapeHealth(c, ch)
 	c.completedRunsCounter.Collect(ch)
+	c.scrapeErrorsCounter.Collect(ch)
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,0 +1,39 @@
+package collector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
+	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour, 500, 5*time.Minute)
+
+	descCh := make(chan *prometheus.Desc, 16)
+	go func() {
+		c.Describe(descCh)
+		close(descCh)
+	}()
+	var descCount int
+	for range descCh {
+		descCount++
+	}
+	// activeRunsDesc, lastRunStatusDesc, scrapeDurationDesc, lastScrapeSuccessDesc,
+	// plus one each from completedRunsCounter and scrapeErrorsCounter.
+	assert.Equal(t, 6, descCount)
+
+	c.RecordScrapeResult("active_runs", 10*time.Millisecond, nil)
+
+	metricCh := make(chan prometheus.Metric, 16)
+	go func() {
+		c.Collect(metricCh)
+		close(metricCh)
+	}()
+	var metricCount int
+	for range metricCh {
+		metricCount++
+	}
+	assert.Positive(t, metricCount)
+}

--- a/internal/collector/completed_runs.go
+++ b/internal/collector/completed_runs.go
@@ -18,7 +18,7 @@ func getUpdatedAfter(base time.Time, lookbackWindow time.Duration) float64 {
 	return float64(base.Add(-lookbackWindow).Unix())
 }
 
-func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) {
+func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) error {
 	c.mutex.Lock()
 	lastSeenUpdateTime := c.lastSeenUpdateTime
 	c.mutex.Unlock()
@@ -62,7 +62,7 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) {
 	})
 	if err != nil {
 		log.Printf("failed to collect completed runs from dagster: %v", err)
-		return
+		return err
 	}
 
 	if maxUpdateTimeSeen > lastSeenUpdateTime {
@@ -70,6 +70,8 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) {
 		c.lastSeenUpdateTime = maxUpdateTimeSeen
 		c.mutex.Unlock()
 	}
+
+	return nil
 }
 
 // lastRunEntry tracks the status of the most recently completed run seen so

--- a/internal/collector/completed_runs_test.go
+++ b/internal/collector/completed_runs_test.go
@@ -54,14 +54,14 @@ func TestCollectCompletedRunsUsesIncrementalUpdatedAfter(t *testing.T) {
 	safetyMargin := 5 * time.Minute
 	c := NewDagsterCollector(t.Context(), ts.URL, lookback, time.Hour, 500, safetyMargin)
 
-	CollectCompletedRuns(t.Context(), c)
+	require.NoError(t, CollectCompletedRuns(t.Context(), c))
 	require.Len(t, seenUpdatedAfter, 1)
 	expectedFirst := getUpdatedAfter(time.Now(), lookback)
 	assert.InDelta(t, expectedFirst, seenUpdatedAfter[0], 5,
 		"first scrape (no watermark yet) should fall back to the lookback window")
 	assert.Equal(t, float64(1000), c.lastSeenUpdateTime, "watermark should advance to the max updateTime seen")
 
-	CollectCompletedRuns(t.Context(), c)
+	require.NoError(t, CollectCompletedRuns(t.Context(), c))
 	require.Len(t, seenUpdatedAfter, 2)
 	assert.Equal(t, float64(1000)-safetyMargin.Seconds(), seenUpdatedAfter[1],
 		"second scrape should use the watermark minus the safety margin, not the full lookback window again")
@@ -89,7 +89,7 @@ func TestCollectCompletedRunsTracksLastRunStatus(t *testing.T) {
 	defer ts.Close()
 
 	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
-	CollectCompletedRuns(t.Context(), c)
+	require.NoError(t, CollectCompletedRuns(t.Context(), c))
 
 	assert.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}].status)
 
@@ -155,10 +155,10 @@ func TestLastRunStatusPersistsAfterFallingOutOfLookbackWindow(t *testing.T) {
 
 	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 
-	CollectCompletedRuns(t.Context(), c)
+	require.NoError(t, CollectCompletedRuns(t.Context(), c))
 	require.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}].status)
 
-	CollectCompletedRuns(t.Context(), c)
+	require.NoError(t, CollectCompletedRuns(t.Context(), c))
 	assert.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}].status,
 		"last known status should survive a scrape with no completed runs in range")
 }
@@ -242,7 +242,7 @@ func TestPruneCompletedRunsCounterRemovesStaleLocationNotInRoster(t *testing.T) 
 	defer ts.Close()
 
 	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
-	CollectCompletedRuns(t.Context(), c)
+	require.NoError(t, CollectCompletedRuns(t.Context(), c))
 
 	metric, err := c.completedRunsCounter.GetMetricWithLabelValues("job_a", "old.module.path", "success")
 	require.NoError(t, err)
@@ -308,13 +308,13 @@ func TestCollectJobLocationsSeedsAndPrunes(t *testing.T) {
 
 	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 
-	CollectJobLocations(t.Context(), c)
+	require.NoError(t, CollectJobLocations(t.Context(), c))
 	assert.Contains(t, c.knownJobs, JobKey{JobName: "job_a", LocationName: "loc_a"})
 
 	metric, err := c.completedRunsCounter.GetMetricWithLabelValues("job_a", "loc_a", "success")
 	require.NoError(t, err)
 	assert.Equal(t, float64(0), testutil.ToFloat64(metric))
 
-	CollectJobLocations(t.Context(), c)
+	require.NoError(t, CollectJobLocations(t.Context(), c))
 	assert.NotContains(t, c.knownJobs, JobKey{JobName: "job_a", LocationName: "loc_a"})
 }

--- a/internal/collector/completed_runs_test.go
+++ b/internal/collector/completed_runs_test.go
@@ -318,3 +318,25 @@ func TestCollectJobLocationsSeedsAndPrunes(t *testing.T) {
 	require.NoError(t, CollectJobLocations(t.Context(), c))
 	assert.NotContains(t, c.knownJobs, JobKey{JobName: "job_a", LocationName: "loc_a"})
 }
+
+func TestCollectCompletedRunsReturnsErrorOnServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	assert.Error(t, CollectCompletedRuns(t.Context(), c))
+}
+
+func TestCollectJobLocationsReturnsErrorOnServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	assert.Error(t, CollectJobLocations(t.Context(), c))
+}

--- a/internal/collector/job_locations.go
+++ b/internal/collector/job_locations.go
@@ -10,13 +10,13 @@ type JobKey struct {
 	LocationName string
 }
 
-func CollectJobLocations(ctx context.Context, c *DagsterCollector) {
+func CollectJobLocations(ctx context.Context, c *DagsterCollector) error {
 	req := getJobLocationsRequest()
 
 	resp, err := getJobLocations(ctx, req, c.dagsterGraphQLEndpoint)
 	if err != nil {
 		log.Printf("failed to collect job locations from dagster: %v", err)
-		return
+		return err
 	}
 
 	known := make(map[JobKey]struct{})
@@ -34,4 +34,6 @@ func CollectJobLocations(ctx context.Context, c *DagsterCollector) {
 	pruneCompletedRunsCounter(c, known)
 	seedCompletedRunsCounter(c, known)
 	pruneLastRunStatus(c, known)
+
+	return nil
 }

--- a/internal/collector/scrape_health.go
+++ b/internal/collector/scrape_health.go
@@ -1,0 +1,49 @@
+package collector
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// RecordScrapeResult records the outcome of one collector's most recent
+// scrape, so it can be reported via dagster_exporter_scrape_duration_seconds,
+// dagster_exporter_last_scrape_success, and dagster_exporter_scrape_errors_total.
+func (c *DagsterCollector) RecordScrapeResult(collectorName string, duration time.Duration, err error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.scrapeDuration[collectorName] = duration.Seconds()
+	c.lastScrapeSuccess[collectorName] = err == nil
+
+	if err != nil {
+		c.scrapeErrorsCounter.WithLabelValues(collectorName).Inc()
+	}
+}
+
+func reflectScrapeHealth(c *DagsterCollector, ch chan<- prometheus.Metric) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for name, duration := range c.scrapeDuration {
+		ch <- prometheus.MustNewConstMetric(
+			c.scrapeDurationDesc,
+			prometheus.GaugeValue,
+			duration,
+			name,
+		)
+	}
+
+	for name, success := range c.lastScrapeSuccess {
+		value := 0.0
+		if success {
+			value = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.lastScrapeSuccessDesc,
+			prometheus.GaugeValue,
+			value,
+			name,
+		)
+	}
+}

--- a/internal/collector/scrape_health_test.go
+++ b/internal/collector/scrape_health_test.go
@@ -1,0 +1,64 @@
+package collector
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordScrapeResultSuccess(t *testing.T) {
+	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour, 500, 5*time.Minute)
+
+	c.RecordScrapeResult("active_runs", 250*time.Millisecond, nil)
+
+	ch := make(chan prometheus.Metric, 8)
+	go func() {
+		reflectScrapeHealth(c, ch)
+		close(ch)
+	}()
+
+	var sawDuration, sawSuccess bool
+	for m := range ch {
+		var dm dto.Metric
+		require.NoError(t, m.Write(&dm))
+
+		switch {
+		case strings.Contains(m.Desc().String(), "dagster_exporter_scrape_duration_seconds"):
+			sawDuration = true
+			assert.InDelta(t, 0.25, dm.GetGauge().GetValue(), 0.001)
+		case strings.Contains(m.Desc().String(), "dagster_exporter_last_scrape_success"):
+			sawSuccess = true
+			assert.Equal(t, float64(1), dm.GetGauge().GetValue())
+		}
+	}
+	assert.True(t, sawDuration, "expected a scrape duration metric")
+	assert.True(t, sawSuccess, "expected a last-scrape-success metric")
+
+	errMetric, err := c.scrapeErrorsCounter.GetMetricWithLabelValues("active_runs")
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), testutil.ToFloat64(errMetric))
+}
+
+func TestRecordScrapeResultFailureIncrementsErrorCounter(t *testing.T) {
+	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour, 500, 5*time.Minute)
+
+	c.RecordScrapeResult("job_locations", 100*time.Millisecond, errors.New("boom"))
+	c.RecordScrapeResult("job_locations", 100*time.Millisecond, errors.New("boom again"))
+
+	errMetric, err := c.scrapeErrorsCounter.GetMetricWithLabelValues("job_locations")
+	require.NoError(t, err)
+	assert.Equal(t, float64(2), testutil.ToFloat64(errMetric),
+		"error counter should accumulate across failed scrapes, not just reflect the latest one")
+
+	c.mutex.Lock()
+	success := c.lastScrapeSuccess["job_locations"]
+	c.mutex.Unlock()
+	assert.False(t, success)
+}

--- a/internal/server/scrape.go
+++ b/internal/server/scrape.go
@@ -15,17 +15,19 @@ import (
 func scrapeDagster(ctx context.Context, c *collector.DagsterCollector) {
 	var wg sync.WaitGroup
 
-	spawn := func(fn func()) {
+	spawn := func(name string, fn func(context.Context, *collector.DagsterCollector) error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			fn()
+			start := time.Now()
+			err := fn(ctx, c)
+			c.RecordScrapeResult(name, time.Since(start), err)
 		}()
 	}
 
-	spawn(func() { collector.CollectJobLocations(ctx, c) })
-	spawn(func() { collector.CollectActiveRuns(ctx, c) })
-	spawn(func() { collector.CollectCompletedRuns(ctx, c) })
+	spawn("job_locations", collector.CollectJobLocations)
+	spawn("active_runs", collector.CollectActiveRuns)
+	spawn("completed_runs", collector.CollectCompletedRuns)
 
 	wg.Wait()
 }

--- a/internal/server/scrape_test.go
+++ b/internal/server/scrape_test.go
@@ -5,8 +5,14 @@ import (
 	"dagster-prometheus-exporter/internal/collector"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScrapeDagsterHonorsContextTimeoutWhenRunningConcurrently(t *testing.T) {
@@ -46,5 +52,47 @@ func TestScrapeDagsterHonorsContextTimeoutWhenRunningConcurrently(t *testing.T) 
 		// Expected: scrapeDagster returned once ctx timed out.
 	case <-time.After(20 * ctxTimeout):
 		t.Fatal("scrapeDagster did not return after its context timed out; a collector is not honoring ctx cancellation")
+	}
+}
+
+func TestScrapeDagsterRecordsSelfHealthMetrics(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+			"data": {
+				"runsOrError": {"__typename": "Runs", "results": []},
+				"repositoriesOrError": {"__typename": "RepositoryConnection", "nodes": []}
+			}
+		}`))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	c := collector.NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+	scrapeDagster(t.Context(), c)
+
+	ch := make(chan prometheus.Metric, 16)
+	go func() {
+		c.Collect(ch)
+		close(ch)
+	}()
+
+	success := map[string]float64{}
+	for m := range ch {
+		if !strings.Contains(m.Desc().String(), "dagster_exporter_last_scrape_success") {
+			continue
+		}
+		var dm dto.Metric
+		require.NoError(t, m.Write(&dm))
+		for _, l := range dm.GetLabel() {
+			if l.GetName() == "collector" {
+				success[l.GetValue()] = dm.GetGauge().GetValue()
+			}
+		}
+	}
+
+	for _, name := range []string{"job_locations", "active_runs", "completed_runs"} {
+		assert.Equal(t, float64(1), success[name], "%s should report a successful scrape", name)
 	}
 }


### PR DESCRIPTION
## What

Add three metrics reporting on the exporter's own scrape health, labeled by `collector` (`job_locations`/`active_runs`/`completed_runs`):

- `dagster_exporter_scrape_duration_seconds` (Gauge)
- `dagster_exporter_last_scrape_success` (Gauge, 1/0)
- `dagster_exporter_scrape_errors_total` (Counter)

`CollectJobLocations`/`CollectActiveRuns`/`CollectCompletedRuns` now return `error` instead of only logging it, so `scrapeDagster` can time each one and record success/failure via a new `DagsterCollector.RecordScrapeResult` method. README gets a new "Exporter self-health" subsection under Metrics.

## Why

Standard Prometheus exporter practice (e.g. node_exporter, blackbox_exporter) is to self-instrument scrape duration/success, so a slow or failing GraphQL call against Dagster is visible directly instead of having to be inferred from gaps or staleness in the `dagster_*` series.

## QA

- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` all pass.
- `go test -race -coverprofile=coverage.txt ./...` passes; `internal/collector` coverage 73.2%, `internal/server` 46.9%.
- Added `internal/collector/scrape_health_test.go` covering success/failure recording and the cumulative error counter.
- Added `TestScrapeDagsterRecordsSelfHealthMetrics` in `internal/server/scrape_test.go`, verifying `scrapeDagster` wires timing/success through to the collector's exported metrics for all three collectors.

## Ref

Closes #28