### PR TITLE
Fix module path to match its actual import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![codecov](https://codecov.io/gh/HirofumiTsuda/dagster-prometheus-exporter/graph/badge.svg)](https://codecov.io/gh/HirofumiTsuda/dagster-prometheus-exporter)
 [![CodeQL](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml)
 [![Go version](https://img.shields.io/github/go-mod/go-version/HirofumiTsuda/dagster-prometheus-exporter)](go.mod)
+[![Go Reference](https://pkg.go.dev/badge/github.com/HirofumiTsuda/dagster-prometheus-exporter.svg)](https://pkg.go.dev/github.com/HirofumiTsuda/dagster-prometheus-exporter)
 [![License: MIT](https://img.shields.io/github/license/HirofumiTsuda/dagster-prometheus-exporter)](LICENSE)
 
 A Prometheus exporter for [Dagster](https://dagster.io/) run metrics. It polls Dagster's GraphQL API on an interval and exposes run counts, statuses, and code-location information as Prometheus metrics.
@@ -143,7 +144,14 @@ dagster_last_run_info{status="failure"}
 
 ## Usage
 
-Build and run the binary directly:
+Install directly with Go:
+
+```sh
+go install github.com/HirofumiTsuda/dagster-prometheus-exporter/cmd/exporter@latest
+DAGSTER_GRAPHQL_ENDPOINT=http://localhost:3000/graphql exporter
+```
+
+Or clone and build it yourself:
 
 ```sh
 go build -o exporter ./cmd/exporter

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"dagster-prometheus-exporter/internal/config"
-	"dagster-prometheus-exporter/internal/server"
+	"github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/config"
+	"github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/server"
 	"log"
 	"os"
 	"os/signal"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module dagster-prometheus-exporter
+module github.com/HirofumiTsuda/dagster-prometheus-exporter
 
 go 1.26.5
 

--- a/internal/server/readyz.go
+++ b/internal/server/readyz.go
@@ -2,8 +2,8 @@ package server
 
 import (
 	"context"
-	"dagster-prometheus-exporter/internal/collector"
 	"encoding/json"
+	"github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/collector"
 	"log"
 	"net/http"
 	"time"

--- a/internal/server/scrape.go
+++ b/internal/server/scrape.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"context"
-	"dagster-prometheus-exporter/internal/collector"
+	"github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/collector"
 	"log"
 	"sync"
 	"time"

--- a/internal/server/scrape_test.go
+++ b/internal/server/scrape_test.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"context"
-	"dagster-prometheus-exporter/internal/collector"
+	"github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/collector"
 	"net/http"
 	"net/http/httptest"
 	"strings"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,9 +2,9 @@ package server
 
 import (
 	"context"
-	"dagster-prometheus-exporter/internal/collector"
-	"dagster-prometheus-exporter/internal/config"
 	"fmt"
+	"github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/collector"
+	"github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/config"
 	"log"
 	"net/http"
 	"time"


### PR DESCRIPTION
## What

- Rename the Go module from the short `dagster-prometheus-exporter` to the full `github.com/HirofumiTsuda/dagster-prometheus-exporter`, matching its real GitHub path, and update the 5 files that import internal packages by the old path.
- Add a pkg.go.dev badge and a `go install` option to the README's Usage section.

## Why

The module path didn't match its actual import path, so `go install github.com/HirofumiTsuda/dagster-prometheus-exporter/cmd/exporter@latest` couldn't work, and pkg.go.dev has never been able to index this module (confirmed: the pkg.go.dev page currently 404s). This was found while looking into ways to make the project more discoverable.

## QA

- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` all pass.
- `go test -race -coverprofile=coverage.txt ./...` passes; coverage unchanged (73.2%/46.9%... actually 83.7%/46.9% per current main).
- Verified the pkg.go.dev badge URL resolves (200).

## Ref

None

---

Note: `go install .../cmd/exporter@latest` won't actually reflect this fix until a new version tag is cut — `@latest` currently resolves to `v0.1.0`, which predates this change.