### PR TITLE
Mark exporter self-health metrics as done in Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ CI (`.github/workflows/ci.yml`) runs all of the above on every push and pull req
 - [x] Per-code-location labeling
 - [x] Latest run status
 - [ ] Run duration (latest completed, and longest-running active run per job)
-- [ ] Exporter self-health metrics (scrape duration/errors)
+- [x] Exporter self-health metrics (scrape duration/errors)
 - [ ] Schedule tick status
 - [ ] Sensor / asset materialization metrics
 - [x] Published container image / tagged release


### PR DESCRIPTION
## What

Check off "Exporter self-health metrics (scrape duration/errors)" in the README's Roadmap.

## Why

PR #37 shipped this (`dagster_exporter_scrape_duration_seconds`, `dagster_exporter_last_scrape_success`, `dagster_exporter_scrape_errors_total`), but the Roadmap checklist was never updated to reflect it.

## QA

Docs-only change, no code impact.

## Ref

None