### PR TITLE
Add a minimal Helm chart for Kubernetes deployment

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,31 @@
+name: Helm Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "charts/**"
+      - ".github/workflows/helm-lint.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "charts/**"
+      - ".github/workflows/helm-lint.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: azure/setup-helm@v4
+
+      - run: helm lint --strict charts/dagster-prometheus-exporter
+
+      - run: helm template charts/dagster-prometheus-exporter
+
+      - name: Render with a representative set of overrides
+        run: |
+          helm template charts/dagster-prometheus-exporter \
+            --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql \
+            --set serviceMonitor.enabled=true

--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ docker build -f docker/exporter.Dockerfile -t dagster-prometheus-exporter .
 docker run -p 9101:9101 -e DAGSTER_GRAPHQL_ENDPOINT=http://dagster:3000/graphql dagster-prometheus-exporter
 ```
 
+Or deploy to Kubernetes with the bundled [Helm chart](charts/dagster-prometheus-exporter):
+
+```sh
+helm install my-dagster-exporter ./charts/dagster-prometheus-exporter \
+  --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
+```
+
 Metrics are then available at `http://localhost:9101/metrics`.
 
 ### Configuration
@@ -224,6 +231,7 @@ CI (`.github/workflows/ci.yml`) runs all of the above on every push and pull req
 - [ ] Schedule tick status
 - [ ] Sensor / asset materialization metrics
 - [x] Published container image / tagged release
+- [x] Helm chart for Kubernetes deployment
 
 ## License
 

--- a/charts/dagster-prometheus-exporter/.helmignore
+++ b/charts/dagster-prometheus-exporter/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.git/
+.gitignore
+.DS_Store
+*.orig
+*.tmp
+*.bak
+*.swp

--- a/charts/dagster-prometheus-exporter/Chart.yaml
+++ b/charts/dagster-prometheus-exporter/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: dagster-prometheus-exporter
+description: A Prometheus exporter for Dagster run metrics
+type: application
+version: 0.1.0
+appVersion: "v0.1.1"
+home: https://github.com/HirofumiTsuda/dagster-prometheus-exporter
+sources:
+  - https://github.com/HirofumiTsuda/dagster-prometheus-exporter
+maintainers:
+  - name: HirofumiTsuda
+    url: https://github.com/HirofumiTsuda

--- a/charts/dagster-prometheus-exporter/README.md
+++ b/charts/dagster-prometheus-exporter/README.md
@@ -1,0 +1,36 @@
+# dagster-prometheus-exporter
+
+A Helm chart for [dagster-prometheus-exporter](https://github.com/HirofumiTsuda/dagster-prometheus-exporter), a Prometheus exporter for Dagster run metrics.
+
+## Installing
+
+This chart isn't published to a chart repository yet (see [#33](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/33) for the plan). For now, install from a local checkout:
+
+```sh
+git clone https://github.com/HirofumiTsuda/dagster-prometheus-exporter.git
+helm install my-dagster-exporter ./dagster-prometheus-exporter/charts/dagster-prometheus-exporter \
+  --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
+```
+
+`env.DAGSTER_GRAPHQL_ENDPOINT` has no sane default for a real deployment and should always be set explicitly. See [values.yaml](values.yaml) for every other setting, which mirror the exporter's own environment variables (see the main [README](../../README.md#configuration)).
+
+## Values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Number of exporter pods. |
+| `image.repository` | `ghcr.io/hirofumitsuda/dagster-prometheus-exporter` | Image to deploy. |
+| `image.tag` | `""` (chart's `appVersion`) | Image tag override. |
+| `port` | `9101` | Single source of truth for the container port, Service port, and the `PORT` env var. |
+| `service.type` | `ClusterIP` | Kubernetes Service type. |
+| `env` | `{}` | Environment variables passed to the exporter via a ConfigMap (`envFrom`). Keys match `internal/config/config.go` exactly. |
+| `resources` | `{}` | Standard pod resource requests/limits. |
+| `podAnnotations` / `podLabels` | `{}` | Extra pod metadata. |
+| `serviceMonitor.enabled` | `false` | Create a prometheus-operator `ServiceMonitor`. Requires the CRD to already be installed. |
+| `serviceMonitor.interval` | `30s` | Scrape interval for the `ServiceMonitor`. |
+| `nameOverride` / `fullnameOverride` | `""` | Override the chart's computed resource name. |
+
+## Notes
+
+- `readinessProbe`/`livenessProbe` are set to `/healthz`, not `/readyz` — `/healthz` doesn't depend on Dagster connectivity, so a Dagster outage doesn't pull the exporter pod out of the Service's endpoints. Doing so would stop Prometheus from scraping it at all, defeating the point of the exporter continuing to serve last-known state during an outage (see the main README's Motivation section).
+- A `checksum/config` pod annotation triggers a rollout whenever `env` changes, since `envFrom`-injected variables are otherwise only read once at container start.

--- a/charts/dagster-prometheus-exporter/templates/NOTES.txt
+++ b/charts/dagster-prometheus-exporter/templates/NOTES.txt
@@ -1,0 +1,16 @@
+dagster-prometheus-exporter has been installed.
+
+{{- if not .Values.env.DAGSTER_GRAPHQL_ENDPOINT }}
+
+WARNING: env.DAGSTER_GRAPHQL_ENDPOINT is not set, so the exporter is
+falling back to its built-in default (http://127.0.0.1:3000/graphql),
+which almost certainly isn't reachable from inside this cluster. Set
+env.DAGSTER_GRAPHQL_ENDPOINT to your Dagster webserver's in-cluster
+Service address.
+{{- end }}
+
+Check that it's scraping successfully:
+
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "dagster-prometheus-exporter.fullname" . }} {{ .Values.port }}:{{ .Values.port }}
+  curl http://localhost:{{ .Values.port }}/readyz
+  curl http://localhost:{{ .Values.port }}/metrics

--- a/charts/dagster-prometheus-exporter/templates/_helpers.tpl
+++ b/charts/dagster-prometheus-exporter/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{- define "dagster-prometheus-exporter.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "dagster-prometheus-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "dagster-prometheus-exporter.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "dagster-prometheus-exporter.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "dagster-prometheus-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dagster-prometheus-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/dagster-prometheus-exporter/templates/configmap.yaml
+++ b/charts/dagster-prometheus-exporter/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dagster-prometheus-exporter.fullname" . }}
+  labels:
+    {{- include "dagster-prometheus-exporter.labels" . | nindent 4 }}
+data:
+  PORT: {{ .Values.port | quote }}
+  {{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/dagster-prometheus-exporter/templates/deployment.yaml
+++ b/charts/dagster-prometheus-exporter/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dagster-prometheus-exporter.fullname" . }}
+  labels:
+    {{- include "dagster-prometheus-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "dagster-prometheus-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Forces a rollout whenever the ConfigMap's contents change, since
+        # envFrom-injected env vars are otherwise only read at container
+        # start and wouldn't pick up the change on their own.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "dagster-prometheus-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "dagster-prometheus-exporter.fullname" . }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/dagster-prometheus-exporter/templates/service.yaml
+++ b/charts/dagster-prometheus-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dagster-prometheus-exporter.fullname" . }}
+  labels:
+    {{- include "dagster-prometheus-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "dagster-prometheus-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/dagster-prometheus-exporter/templates/servicemonitor.yaml
+++ b/charts/dagster-prometheus-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dagster-prometheus-exporter.fullname" . }}
+  labels:
+    {{- include "dagster-prometheus-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "dagster-prometheus-exporter.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/charts/dagster-prometheus-exporter/values.yaml
+++ b/charts/dagster-prometheus-exporter/values.yaml
@@ -1,0 +1,49 @@
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/hirofumitsuda/dagster-prometheus-exporter
+  # Defaults to the chart's appVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Port the exporter listens on. Used for the container port, the Service
+# port, and the PORT env var — keep it a single value so those three can't
+# drift out of sync.
+port: 9101
+
+service:
+  type: ClusterIP
+
+# Passed to the exporter as environment variables via a ConfigMap. Keys
+# match internal/config/config.go exactly (see the README's Configuration
+# table). DAGSTER_GRAPHQL_ENDPOINT has no sane default for a real
+# deployment — it must be set here.
+#
+# If Dagster itself was installed via the official chart
+# (https://github.com/dagster-io/dagster/tree/master/helm/dagster), its
+# webserver Service is named "<release-name>-webserver" and listens on
+# port 80 by default — e.g. for `helm install dagster dagster/dagster -n
+# dagster`, that's http://dagster-webserver.dagster.svc.cluster.local/graphql.
+env: {}
+  # DAGSTER_GRAPHQL_ENDPOINT: "http://dagster-webserver.dagster.svc.cluster.local/graphql"
+  # LOOKBACK_WINDOW_MINUTES: "15"
+  # CACHE_TTL_MINUTES: "300"
+  # DAGSTER_SCRAPING_INTERVAL_SECONDS: "15"
+  # DAGSTER_SCRAPING_TIMEOUT_SECONDS: "10"
+  # RUNS_PAGE_SIZE: "500"
+  # RUNS_UPDATED_AFTER_SAFETY_MARGIN_MINUTES: "5"
+
+resources: {}
+
+podAnnotations: {}
+podLabels: {}
+
+# For prometheus-operator setups. Requires the ServiceMonitor CRD to already
+# be installed in the cluster.
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  additionalLabels: {}


### PR DESCRIPTION
## What

Add `charts/dagster-prometheus-exporter/`: a minimal Helm chart with a Deployment, Service, ConfigMap, and an optional prometheus-operator `ServiceMonitor`. Also adds `.github/workflows/helm-lint.yml` (lint + template, scoped to `charts/**` changes) and a Kubernetes install option in the main README.

## Why

Lowers the barrier to running this exporter on Kubernetes. Design decisions (discussed on #33):

- Env vars go through a ConfigMap via `envFrom`, with a `checksum/config` pod annotation to trigger a rollout when the ConfigMap changes (`envFrom` is only read once at container start, so it wouldn't otherwise pick up changes).
- `readinessProbe`/`livenessProbe` point at `/healthz`, not `/readyz`. `/readyz` depends on live Dagster connectivity — gating the Service's endpoints on it would pull the pod out of rotation during a real Dagster outage, which is exactly the situation this exporter is designed to stay observable through (it keeps serving last-known state on `/metrics` rather than going dark; see the main README's Motivation section).

Chart publishing (OCI/GitHub Pages + Artifact Hub registration) and a kind-based e2e test against a real Dagster instance are intentionally out of scope here — tracked in #44 and a new TODO.md entry respectively.

## QA

- `helm lint --strict charts/dagster-prometheus-exporter` passes.
- `helm template` verified with default values and with representative `--set` overrides (`env.DAGSTER_GRAPHQL_ENDPOINT`, `env.RUNS_PAGE_SIZE`, `serviceMonitor.enabled`, `fullnameOverride`) — ConfigMap/checksum/probe/ServiceMonitor output all confirmed correct.
- Validated `.github/workflows/helm-lint.yml` YAML syntax.

## Ref

Closes #33