### PR TITLE
Publish the Helm chart to GHCR as an OCI artifact

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,50 @@
+name: Helm Publish
+
+on:
+  push:
+    tags:
+      - "chart-v*.*.*"
+  workflow_dispatch: {}
+
+env:
+  REGISTRY: ghcr.io
+  CHART_PATH: charts/dagster-prometheus-exporter
+  OCI_REPO: oci://ghcr.io/hirofumitsuda/charts
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: azure/setup-helm@v4
+
+      - name: Verify tag matches Chart.yaml version
+        if: github.event_name == 'push'
+        run: |
+          tag_version="${GITHUB_REF_NAME#chart-v}"
+          chart_version="$(helm show chart "$CHART_PATH" | awk '/^version:/ {print $2}')"
+          if [ "$tag_version" != "$chart_version" ]; then
+            echo "Tag chart-v$tag_version does not match Chart.yaml version $chart_version" >&2
+            exit 1
+          fi
+
+      - run: helm lint --strict "$CHART_PATH"
+
+      - name: Package chart
+        run: helm package "$CHART_PATH" --destination .
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to GHCR (OCI)
+        run: |
+          chart_package="$(ls dagster-prometheus-exporter-*.tgz)"
+          helm push "$chart_package" "$OCI_REPO"

--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ docker build -f docker/exporter.Dockerfile -t dagster-prometheus-exporter .
 docker run -p 9101:9101 -e DAGSTER_GRAPHQL_ENDPOINT=http://dagster:3000/graphql dagster-prometheus-exporter
 ```
 
-Or deploy to Kubernetes with the bundled [Helm chart](charts/dagster-prometheus-exporter):
+Or deploy to Kubernetes with the [Helm chart](charts/dagster-prometheus-exporter), published as an OCI artifact on GHCR:
 
 ```sh
-helm install my-dagster-exporter ./charts/dagster-prometheus-exporter \
+helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
+  --version 0.1.0 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 

--- a/charts/dagster-prometheus-exporter/README.md
+++ b/charts/dagster-prometheus-exporter/README.md
@@ -4,7 +4,15 @@ A Helm chart for [dagster-prometheus-exporter](https://github.com/HirofumiTsuda/
 
 ## Installing
 
-This chart isn't published to a chart repository yet (see [#33](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/33) for the plan). For now, install from a local checkout:
+The chart is published as an OCI artifact to GHCR:
+
+```sh
+helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
+  --version 0.1.0 \
+  --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
+```
+
+Or install from a local checkout:
 
 ```sh
 git clone https://github.com/HirofumiTsuda/dagster-prometheus-exporter.git


### PR DESCRIPTION
## What

Adds `.github/workflows/helm-publish.yml`, which packages `charts/dagster-prometheus-exporter` and pushes it to `oci://ghcr.io/hirofumitsuda/charts` on `chart-v*.*.*` tags. Updates the install instructions in the main README and the chart's own README to reference the OCI chart.

## Why

First stage of the two-stage Helm chart publishing plan tracked in TODO.md (second stage — Artifact Hub registration — is a separate, manual follow-up once the chart is actually publishable). The chart was merged in #45 with local-checkout-only install instructions; this makes it installable with a plain `helm install oci://...` like most published charts.

The publish tag is `chart-v*.*.*`, distinct from the app's `v*.*.*` release tags used by `docker-publish.yml`, since the Helm chart version (`Chart.yaml`'s `version`) and the app version (`appVersion`) move independently — a chart-only fix (e.g. a template bug) shouldn't require cutting a new app release. The workflow verifies the tag's version matches `Chart.yaml` before pushing, to catch a mismatched tag early.

## QA

- `helm lint --strict charts/dagster-prometheus-exporter` passes.
- `helm package charts/dagster-prometheus-exporter` succeeds locally, producing `dagster-prometheus-exporter-0.1.0.tgz`.
- Validated `helm-publish.yml` YAML syntax.
- The actual OCI push to GHCR isn't exercised by this PR (it only runs on a `chart-v*.*.*` tag); publishing the first chart version is a manual follow-up after merge, same as the Docker image release flow. Note the resulting GHCR package will default to private and need to be switched to public once, same as `ghcr.io/hirofumitsuda/dagster-prometheus-exporter` was.

## Ref

Continuation of #33 / #45.