### PR TITLE
Add dagster_last_run_duration_seconds metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The per-job metrics are labeled with `job_name` and `location` (the Dagster code
 | `dagster_active_runs` | Gauge | `job_name`, `location`, `status` | Number of currently active runs (`queued`, `starting`, `started`) per job. Jobs with no active runs are reported as `0` rather than omitted. |
 | `dagster_completed_runs_total` | Counter | `job_name`, `location`, `status` | Total number of completed runs (`success`, `failure`) per job, since the exporter started. Jobs that have never run are seeded at `0`. Series for jobs that no longer exist in Dagster are deleted automatically. |
 | `dagster_last_run_info` | Gauge | `job_name`, `location`, `status` | Always `1`; an "info" metric (same pattern as `kube_pod_info`) reporting the status of the most recently completed run per job. Kept until a newer completion supersedes it or the job is removed from Dagster — it does not disappear just because nothing has completed recently. Use the `status` label to tell success from failure, e.g. in a Grafana table panel. |
+| `dagster_last_run_duration_seconds` | Gauge | `job_name`, `location`, `status` | Duration (`endTime - creationTime`) of the most recently completed run per job. Tracks the same run as `dagster_last_run_info` (same lifetime, same `status` label), so a job that has never completed a run has no series for either — there's no seeded `0`. |
 | `dagster_code_location_load_error` | Gauge | `location` | `1` if that code location most recently failed to load (e.g. a broken import in user code), `0` if it loaded successfully. A code location can fail to load independently of any job/run activity — `dagster_active_runs`/`dagster_completed_runs_total` alone can't distinguish "this location has zero jobs" from "this location is broken," so this metric exists to surface that failure mode explicitly. The load-error message and stack trace are logged, not attached as a label, to avoid unbounded label cardinality. |
 
 ### Exporter self-health
@@ -115,6 +116,8 @@ dagster_completed_runs_total{job_name="failing_job",location="dev-dagster-worksp
 
 dagster_last_run_info{job_name="heavy_job",location="dev-dagster-workspace",status="success"} 1
 dagster_last_run_info{job_name="failing_job",location="dev-dagster-workspace",status="failure"} 1
+
+dagster_last_run_duration_seconds{job_name="heavy_job",location="dev-dagster-workspace",status="success"} 32.34893083572388
 ```
 
 ### PromQL examples
@@ -133,6 +136,9 @@ sum(rate(dagster_completed_runs_total[5m]))
 
 # Jobs whose last run failed
 dagster_last_run_info{status="failure"}
+
+# Slowest jobs by their most recent run duration
+topk(5, dagster_last_run_duration_seconds)
 ```
 
 ## Endpoints
@@ -251,7 +257,8 @@ CI (`.github/workflows/ci.yml`) runs all of the above — Go steps only when `.g
 - [x] Completed runs (seeded for idle jobs, pruned for removed jobs)
 - [x] Per-code-location labeling
 - [x] Latest run status
-- [ ] Run duration (latest completed, and longest-running active run per job)
+- [x] Latest completed run duration
+- [ ] Running duration (longest-running active run per job)
 - [x] Exporter self-health metrics (scrape duration/errors)
 - [x] Code location load error visibility
 - [ ] Schedule tick status

--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -192,6 +192,129 @@
         "x": 12,
         "y": 13
       }
+    },
+    {
+      "title": "Latest Run Duration by Job",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "dagster_last_run_duration_seconds",
+          "legendFormat": "{{job_name}} ({{location}}) {{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      }
+    },
+    {
+      "title": "Broken Code Locations",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(dagster_code_location_load_error)",
+          "legendFormat": "broken"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 21
+      }
+    },
+    {
+      "title": "Code Location Status",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "dagster_code_location_load_error",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "OK",
+                        "color": "green"
+                      },
+                      "1": {
+                        "text": "Load error",
+                        "color": "red"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 21
+      }
     }
   ],
   "templating": {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -21,6 +21,7 @@ type DagsterCollector struct {
 	lastScrapeSuccessDesc     *prometheus.Desc
 	scrapeErrorsCounter       *prometheus.CounterVec
 	codeLocationLoadErrorDesc *prometheus.Desc
+	lastRunDurationDesc       *prometheus.Desc
 
 	mutex                   sync.Mutex
 	activeRunsCounts        map[ActiveRunKey]int
@@ -109,6 +110,12 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"location"},
 			nil,
 		),
+		lastRunDurationDesc: prometheus.NewDesc(
+			"dagster_last_run_duration_seconds",
+			"Duration of the most recently completed run for a job (endTime - creationTime)",
+			[]string{"job_name", "location", "status"},
+			nil,
+		),
 		processedRuns:                cache,
 		lookbackWindow:               lookbackWindow,
 		lastRunStatus:                make(map[JobKey]lastRunEntry),
@@ -126,13 +133,14 @@ func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.scrapeDurationDesc
 	ch <- c.lastScrapeSuccessDesc
 	ch <- c.codeLocationLoadErrorDesc
+	ch <- c.lastRunDurationDesc
 	c.completedRunsCounter.Describe(ch)
 	c.scrapeErrorsCounter.Describe(ch)
 }
 
 func (c *DagsterCollector) Collect(ch chan<- prometheus.Metric) {
 	reflectActiveRuns(c, ch)
-	reflectLastRunStatus(c, ch)
+	reflectLastRun(c, ch)
 	reflectScrapeHealth(c, ch)
 	reflectCodeLocationStatus(c, ch)
 	c.completedRunsCounter.Collect(ch)

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -21,9 +21,9 @@ func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
 		descCount++
 	}
 	// activeRunsDesc, lastRunStatusDesc, scrapeDurationDesc, lastScrapeSuccessDesc,
-	// codeLocationLoadErrorDesc, plus one each from completedRunsCounter and
-	// scrapeErrorsCounter.
-	assert.Equal(t, 7, descCount)
+	// codeLocationLoadErrorDesc, lastRunDurationDesc, plus one each from
+	// completedRunsCounter and scrapeErrorsCounter.
+	assert.Equal(t, 8, descCount)
 
 	c.RecordScrapeResult("active_runs", 10*time.Millisecond, nil)
 

--- a/internal/collector/completed_runs.go
+++ b/internal/collector/completed_runs.go
@@ -46,7 +46,11 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) error {
 
 			key := JobKey{JobName: result.JobName, LocationName: location}
 			if current, ok := c.lastRunStatus[key]; !ok || result.EndTime > current.endTime {
-				c.lastRunStatus[key] = lastRunEntry{status: result.Status, endTime: result.EndTime}
+				c.lastRunStatus[key] = lastRunEntry{
+					status:   result.Status,
+					endTime:  result.EndTime,
+					duration: result.EndTime - result.CreationTime,
+				}
 			}
 
 			if item := c.processedRuns.Get(result.RunId); item != nil {
@@ -74,25 +78,40 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) error {
 	return nil
 }
 
-// lastRunEntry tracks the status of the most recently completed run seen so
-// far for a job, so dagster_last_run_info keeps reporting it even after the
-// run falls outside the completed-runs lookback window.
+// lastRunEntry tracks the status and duration of the most recently completed
+// run seen so far for a job, so dagster_last_run_info/dagster_last_run_duration_seconds
+// keep reporting it even after the run falls outside the completed-runs
+// lookback window.
 type lastRunEntry struct {
-	status  string
-	endTime float64
+	status   string
+	endTime  float64
+	duration float64
 }
 
-func reflectLastRunStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
+// reflectLastRun emits both dagster_last_run_info and
+// dagster_last_run_duration_seconds from a single locked pass over
+// c.lastRunStatus — they're two views of the same underlying entry, so
+// iterating it twice (with two separate locks) would be pure overhead.
+func reflectLastRun(c *DagsterCollector, ch chan<- prometheus.Metric) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	for key, entry := range c.lastRunStatus {
+		status := strings.ToLower(entry.status)
 		ch <- prometheus.MustNewConstMetric(
 			c.lastRunStatusDesc,
 			prometheus.GaugeValue,
 			1,
 			key.JobName,
 			key.LocationName,
-			strings.ToLower(entry.status),
+			status,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.lastRunDurationDesc,
+			prometheus.GaugeValue,
+			entry.duration,
+			key.JobName,
+			key.LocationName,
+			status,
 		)
 	}
 }

--- a/internal/collector/completed_runs_test.go
+++ b/internal/collector/completed_runs_test.go
@@ -67,7 +67,7 @@ func TestCollectCompletedRunsUsesIncrementalUpdatedAfter(t *testing.T) {
 		"second scrape should use the watermark minus the safety margin, not the full lookback window again")
 }
 
-func TestCollectCompletedRunsTracksLastRunStatus(t *testing.T) {
+func TestCollectCompletedRunsTracksLastRunStatusAndDuration(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -76,8 +76,8 @@ func TestCollectCompletedRunsTracksLastRunStatus(t *testing.T) {
 				"runsOrError": {
 					"__typename": "Runs",
 					"results": [
-						{"runId": "run_1", "jobName": "job_a", "status": "FAILURE", "endTime": 100, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "loc_a"}},
-						{"runId": "run_2", "jobName": "job_a", "status": "SUCCESS", "endTime": 200, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "loc_a"}}
+						{"runId": "run_1", "jobName": "job_a", "status": "FAILURE", "creationTime": 0, "endTime": 100, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "loc_a"}},
+						{"runId": "run_2", "jobName": "job_a", "status": "SUCCESS", "creationTime": 150, "endTime": 200, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "loc_a"}}
 					]
 				}
 			}
@@ -93,27 +93,44 @@ func TestCollectCompletedRunsTracksLastRunStatus(t *testing.T) {
 
 	assert.Equal(t, "SUCCESS", c.lastRunStatus[JobKey{JobName: "job_a", LocationName: "loc_a"}].status)
 
+	// job_never_ran has never had a completed run, so it has nothing to
+	// report yet: no seeded 0 duration, no seeded "unknown" status.
+	neverRanKey := JobKey{JobName: "job_never_ran", LocationName: "loc_a"}
+	assert.NotContains(t, c.lastRunStatus, neverRanKey)
+
 	ch := make(chan prometheus.Metric, 8)
 	go func() {
-		reflectLastRunStatus(c, ch)
+		reflectLastRun(c, ch)
 		close(ch)
 	}()
 
-	var metrics []prometheus.Metric
+	var infoMetric, durationMetric *dto.Metric
 	for m := range ch {
-		metrics = append(metrics, m)
+		var dm dto.Metric
+		require.NoError(t, m.Write(&dm))
+		switch {
+		case strings.Contains(m.Desc().String(), "dagster_last_run_info"):
+			infoMetric = &dm
+		case strings.Contains(m.Desc().String(), "dagster_last_run_duration_seconds"):
+			durationMetric = &dm
+		}
 	}
-	require.Len(t, metrics, 1)
+	require.NotNil(t, infoMetric, "expected a dagster_last_run_info series")
+	require.NotNil(t, durationMetric, "expected a dagster_last_run_duration_seconds series")
 
-	var m dto.Metric
-	require.NoError(t, metrics[0].Write(&m))
-	assert.Equal(t, float64(1), m.GetGauge().GetValue())
+	assert.Equal(t, float64(1), infoMetric.GetGauge().GetValue())
+	assert.Equal(t, float64(50), durationMetric.GetGauge().GetValue(),
+		"duration should be endTime - creationTime of the most recent run (200-150), not the earlier one (100-0)")
 
-	labels := make(map[string]string)
-	for _, l := range m.GetLabel() {
-		labels[l.GetName()] = l.GetValue()
+	for _, m := range []*dto.Metric{infoMetric, durationMetric} {
+		labels := make(map[string]string)
+		for _, l := range m.GetLabel() {
+			labels[l.GetName()] = l.GetValue()
+		}
+		assert.Equal(t, "job_a", labels["job_name"])
+		assert.Equal(t, "loc_a", labels["location"])
+		assert.Equal(t, "success", labels["status"])
 	}
-	assert.Equal(t, "success", labels["status"])
 }
 
 func TestLastRunStatusPersistsAfterFallingOutOfLookbackWindow(t *testing.T) {


### PR DESCRIPTION
## What

Adds a `dagster_last_run_duration_seconds{job_name,location,status}` gauge reporting the duration (`endTime - creationTime`) of the most recently completed run per job.

Implementation-wise, this extends `lastRunEntry` (the struct that already backs `dagster_last_run_info`) with a `duration` field, and merges `reflectLastRunStatus`/the new duration reflector into a single `reflectLastRun` that emits both `dagster_last_run_info` and `dagster_last_run_duration_seconds` from one locked pass over `lastRunStatus` — they're two views of the exact same underlying entry, so iterating/locking twice was pure overhead.

Also updates the Grafana dev dashboard:
- New "Latest Run Duration by Job" timeseries panel for this metric.
- New "Broken Code Locations" (stat) and "Code Location Status" (table) panels for `dagster_code_location_load_error`, which was added in #38 but never got a dashboard panel.

## Why

Closes #29. The existing "keep the last known state" pattern (`lastRunEntry`) already tracked everything needed for this except the duration itself, so this is a straightforward extension of it, as the issue suggested.

A job that has never completed a run has no series for this metric — no seeded `0` — consistent with `dagster_last_run_info`'s existing behavior (confirmed via a new test, `TestCollectCompletedRunsTracksLastRunStatusAndDuration`).

## QA

- `go build ./...`, `go vet ./...`, `go test ./... -race`, `gofmt -l .`, `golangci-lint run ./...` all pass.
- `uvx ruff check .` passes (Grafana JSON isn't Python, unaffected, but re-ran since `python-lint` runs on this repo now per #49).
- Updated/merged the relevant collector test into `TestCollectCompletedRunsTracksLastRunStatusAndDuration`, which checks both `dagster_last_run_info` and `dagster_last_run_duration_seconds` come from a single `reflectLastRun` call, with the correct value (duration of the *most recent* completed run, not an earlier one for the same job) and that a never-run job has no series for either.
- Updated `collector_test.go`'s `Describe`/`Collect` desc-count assertion (7 → 8) for the new `Desc`.
- Manually verified end-to-end against a real Dagster 1.13.15 dev instance: launched an actual job run via the GraphQL API, waited for it to complete, and confirmed `/metrics` reports `dagster_last_run_duration_seconds{job_name="heavy_job",location="dev-dagster-location",status="success"} 32.34893083572388`.
- Spun up Prometheus + Grafana against that same exporter and confirmed via the Grafana/Prometheus HTTP APIs that the new panels' queries (`dagster_last_run_duration_seconds`, `dagster_code_location_load_error`, `sum(dagster_code_location_load_error)`) return the expected real data and the dashboard JSON provisions without error.
- Updated README: new metric row, Example output, a new PromQL example, and the Roadmap checkbox.

## Ref
Closes #29