### PR TITLE
Add dagster_active_run_duration_seconds metric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     outputs:
       go: ${{ steps.filter.outputs.go }}
       python: ${{ steps.filter.outputs.python }}
+      grafana: ${{ steps.filter.outputs.grafana }}
     steps:
       - uses: actions/checkout@v7
 
@@ -27,6 +28,9 @@ jobs:
             python:
               - "**.py"
               - pyproject.toml
+              - .github/workflows/ci.yml
+            grafana:
+              - "dev/grafana/dashboards/**.json"
               - .github/workflows/ci.yml
 
   test:
@@ -77,3 +81,17 @@ jobs:
       - uses: astral-sh/setup-uv@v9.0.0
 
       - run: uvx ruff@0.16.2 check .
+
+  grafana-lint:
+    needs: changes
+    if: needs.changes.outputs.grafana == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check dashboard JSON is valid and jq-formatted
+        run: |
+          for f in dev/grafana/dashboards/*.json; do
+            jq empty "$f"
+            diff <(jq . "$f") "$f"
+          done

--- a/README.md
+++ b/README.md
@@ -142,8 +142,11 @@ sum(rate(dagster_completed_runs_total[5m]))
 # Jobs whose last run failed
 dagster_last_run_info{status="failure"}
 
-# Active runs that have been queued/starting/started for over 10 minutes
-dagster_active_run_duration_seconds > 600
+# Alert: some job has a run that's been stuck in QUEUED for over 10 minutes.
+# dagster_active_runs alone can't tell "5 runs queued, all fine, just churning
+# through fast" apart from "5 runs queued, one of them stuck for 2 hours" —
+# both look like active_runs{status="queued"} == 5. This catches the latter.
+dagster_active_run_duration_seconds{status="queued"} > 600
 
 # Slowest jobs by their most recent run duration
 topk(5, dagster_last_run_duration_seconds)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ The per-job metrics are labeled with `job_name` and `location` (the Dagster code
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `dagster_active_runs` | Gauge | `job_name`, `location`, `status` | Number of currently active runs (`queued`, `starting`, `started`) per job. Jobs with no active runs are reported as `0` rather than omitted. |
+| `dagster_active_runs` | Gauge | `job_name`, `location`, `status` | Number of currently active runs (`queued`, `starting`, `started`) per job. Jobs with no active runs are reported as `0` rather than omitted. Each scrape re-queries Dagster for whatever is active *at that instant* (unlike the completed-runs collector, this isn't incremental) — a run that passes through `queued`/`starting`/`started` and finishes entirely between two scrapes is never observed in any active status at all. Shortening the scrape interval narrows this blind spot but can't close it. |
+| `dagster_active_run_duration_seconds` | Gauge | `job_name`, `location`, `status` | Elapsed time (`now - updateTime`) of the longest-waiting/longest-running active run per job and status — the max across that group, not a sum or average. Dagster only bumps a run's `updateTime` on a run-level status transition (not on step-level events like op start/success), so it marks exactly when the run entered its *current* status — e.g. for `started` this is time-in-execution, not time-since-queued. `run_id` isn't a label (it would grow unbounded), so this is the closest available signal for "how long has the oldest run in this group been stuck here," useful for spotting queue backlogs. `0` when there are no active runs in that group, same as `dagster_active_runs` — and it has the same scrape-interval blind spot described above. |
 | `dagster_completed_runs_total` | Counter | `job_name`, `location`, `status` | Total number of completed runs (`success`, `failure`) per job, since the exporter started. Jobs that have never run are seeded at `0`. Series for jobs that no longer exist in Dagster are deleted automatically. |
 | `dagster_last_run_info` | Gauge | `job_name`, `location`, `status` | Always `1`; an "info" metric (same pattern as `kube_pod_info`) reporting the status of the most recently completed run per job. Kept until a newer completion supersedes it or the job is removed from Dagster — it does not disappear just because nothing has completed recently. Use the `status` label to tell success from failure, e.g. in a Grafana table panel. |
 | `dagster_last_run_duration_seconds` | Gauge | `job_name`, `location`, `status` | Duration (`endTime - creationTime`) of the most recently completed run per job. Tracks the same run as `dagster_last_run_info` (same lifetime, same `status` label), so a job that has never completed a run has no series for either — there's no seeded `0`. |
@@ -109,6 +110,10 @@ These report on the exporter itself — whether its own scrapes of Dagster are s
 dagster_active_runs{job_name="heavy_job",location="dev-dagster-workspace",status="queued"} 0
 dagster_active_runs{job_name="heavy_job",location="dev-dagster-workspace",status="started"} 1
 dagster_active_runs{job_name="heavy_job",location="dev-dagster-workspace",status="starting"} 0
+
+dagster_active_run_duration_seconds{job_name="heavy_job",location="dev-dagster-workspace",status="queued"} 0
+dagster_active_run_duration_seconds{job_name="heavy_job",location="dev-dagster-workspace",status="started"} 5.761711018
+dagster_active_run_duration_seconds{job_name="heavy_job",location="dev-dagster-workspace",status="starting"} 0
 
 dagster_completed_runs_total{job_name="heavy_job",location="dev-dagster-workspace",status="failure"} 0
 dagster_completed_runs_total{job_name="heavy_job",location="dev-dagster-workspace",status="success"} 12
@@ -136,6 +141,9 @@ sum(rate(dagster_completed_runs_total[5m]))
 
 # Jobs whose last run failed
 dagster_last_run_info{status="failure"}
+
+# Active runs that have been queued/starting/started for over 10 minutes
+dagster_active_run_duration_seconds > 600
 
 # Slowest jobs by their most recent run duration
 topk(5, dagster_last_run_duration_seconds)
@@ -258,7 +266,7 @@ CI (`.github/workflows/ci.yml`) runs all of the above — Go steps only when `.g
 - [x] Per-code-location labeling
 - [x] Latest run status
 - [x] Latest completed run duration
-- [ ] Running duration (longest-running active run per job)
+- [x] Running duration (longest-running active run per job)
 - [x] Exporter self-health metrics (scrape duration/errors)
 - [x] Code location load error visibility
 - [ ] Schedule tick status

--- a/README.md
+++ b/README.md
@@ -257,7 +257,13 @@ The `dev/` Python code (used by the local dev stack, not shipped in the exporter
 uvx ruff check .
 ```
 
-CI (`.github/workflows/ci.yml`) runs all of the above — Go steps only when `.go`/`go.mod`/`go.sum` change, the Ruff step only when `.py`/`pyproject.toml` change — on every push and pull request.
+The Grafana dashboard JSON (`dev/grafana/dashboards/*.json`) is kept `jq`-formatted so diffs stay readable; after editing it, reformat with:
+
+```sh
+jq . dev/grafana/dashboards/dagster-dashboard.json > /tmp/dashboard.json && mv /tmp/dashboard.json dev/grafana/dashboards/dagster-dashboard.json
+```
+
+CI (`.github/workflows/ci.yml`) runs all of the above — Go steps only when `.go`/`go.mod`/`go.sum` change, the Ruff step only when `.py`/`pyproject.toml` change, the dashboard check only when `dev/grafana/dashboards/**.json` changes — on every push and pull request.
 
 ## Roadmap
 

--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -216,6 +216,28 @@
       }
     },
     {
+      "title": "Active Run Duration by Job",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "dagster_active_run_duration_seconds",
+          "legendFormat": "{{job_name}} ({{location}}) {{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      }
+    },
+    {
       "title": "Broken Code Locations",
       "type": "stat",
       "targets": [

--- a/internal/collector/active_runs.go
+++ b/internal/collector/active_runs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -18,8 +19,32 @@ type ActiveRunKey struct {
 	Status       string
 }
 
+// activeRunAggregate rolls up every active run sharing an ActiveRunKey
+// (job x location x status) into the two numbers dagster_active_runs and
+// dagster_active_run_duration_seconds report: how many there are, and how
+// long the longest-waiting/longest-running one among them has been in that
+// state. Using run_id as a label instead would grow unbounded, so per-run
+// detail is deliberately not kept past this aggregation.
+type activeRunAggregate struct {
+	count      int
+	maxElapsed float64
+}
+
+// elapsedSince returns how long run has been in its current status, as of
+// now. Dagster only bumps a run's updateTime on a run-level status-transition
+// event (RUN_ENQUEUED/RUN_STARTING/RUN_START/...), not on step-level events
+// (op start/success, asset materializations, ...) — see
+// EVENT_TYPE_TO_PIPELINE_RUN_STATUS / SqlRunStorage.handle_run_event in
+// Dagster's source. So updateTime is exactly "when this run entered its
+// current status" for every active status, without needing to special-case
+// STARTED with a separate startTime field.
+func elapsedSince(run Run, now time.Time) float64 {
+	return now.Sub(time.Unix(int64(run.UpdateTime), 0)).Seconds()
+}
+
 func CollectActiveRuns(ctx context.Context, c *DagsterCollector) error {
-	counts := make(map[ActiveRunKey]int)
+	aggregates := make(map[ActiveRunKey]activeRunAggregate)
+	now := time.Now()
 
 	err := fetchRunPages(ctx, activeStatuses, 0, c.dagsterGraphQLEndpoint, c.runsPageSize, func(page []Run) error {
 		for _, run := range page {
@@ -32,7 +57,13 @@ func CollectActiveRuns(ctx context.Context, c *DagsterCollector) error {
 				LocationName: location,
 				Status:       run.Status,
 			}
-			counts[key]++
+
+			agg := aggregates[key]
+			agg.count++
+			if elapsed := elapsedSince(run, now); elapsed > agg.maxElapsed {
+				agg.maxElapsed = elapsed
+			}
+			aggregates[key] = agg
 		}
 		return nil
 	})
@@ -51,27 +82,40 @@ func CollectActiveRuns(ctx context.Context, c *DagsterCollector) error {
 				LocationName: jobKey.LocationName,
 				Status:       status,
 			}
-			if _, ok := counts[key]; !ok {
-				counts[key] = 0
+			if _, ok := aggregates[key]; !ok {
+				aggregates[key] = activeRunAggregate{}
 			}
 		}
 	}
 
-	c.activeRunsCounts = counts
+	c.activeRunAggregates = aggregates
 	return nil
 }
 
+// reflectActiveRuns emits both dagster_active_runs and
+// dagster_active_run_duration_seconds from a single locked pass over
+// c.activeRunAggregates — they're two views of the same aggregate, so
+// iterating it twice (with two separate locks) would be pure overhead.
 func reflectActiveRuns(c *DagsterCollector, ch chan<- prometheus.Metric) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	for key, count := range c.activeRunsCounts {
+	for key, agg := range c.activeRunAggregates {
+		status := strings.ToLower(key.Status)
 		ch <- prometheus.MustNewConstMetric(
 			c.activeRunsDesc,
 			prometheus.GaugeValue,
-			float64(count),
+			float64(agg.count),
 			key.JobName,
 			key.LocationName,
-			strings.ToLower(key.Status),
+			status,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.activeRunDurationDesc,
+			prometheus.GaugeValue,
+			agg.maxElapsed,
+			key.JobName,
+			key.LocationName,
+			status,
 		)
 	}
 }

--- a/internal/collector/active_runs_test.go
+++ b/internal/collector/active_runs_test.go
@@ -1,12 +1,17 @@
 package collector
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCollectActiveRunsLocationLabel(t *testing.T) {
@@ -33,8 +38,8 @@ func TestCollectActiveRunsLocationLabel(t *testing.T) {
 	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 	assert.NoError(t, CollectActiveRuns(t.Context(), c))
 
-	assert.Equal(t, 1, c.activeRunsCounts[ActiveRunKey{JobName: "job_a", LocationName: "loc_a", Status: "STARTED"}])
-	assert.Equal(t, 1, c.activeRunsCounts[ActiveRunKey{JobName: "job_b", LocationName: unknownLocationName, Status: "QUEUED"}])
+	assert.Equal(t, 1, c.activeRunAggregates[ActiveRunKey{JobName: "job_a", LocationName: "loc_a", Status: "STARTED"}].count)
+	assert.Equal(t, 1, c.activeRunAggregates[ActiveRunKey{JobName: "job_b", LocationName: unknownLocationName, Status: "QUEUED"}].count)
 }
 
 func TestCollectActiveRunsZeroFillsKnownJobs(t *testing.T) {
@@ -63,7 +68,9 @@ func TestCollectActiveRunsZeroFillsKnownJobs(t *testing.T) {
 	assert.NoError(t, CollectActiveRuns(t.Context(), c))
 
 	for _, status := range activeStatuses {
-		assert.Equal(t, 0, c.activeRunsCounts[ActiveRunKey{JobName: "never_run_job", LocationName: "loc_a", Status: status}])
+		agg := c.activeRunAggregates[ActiveRunKey{JobName: "never_run_job", LocationName: "loc_a", Status: status}]
+		assert.Equal(t, 0, agg.count)
+		assert.Equal(t, float64(0), agg.maxElapsed)
 	}
 }
 
@@ -76,4 +83,73 @@ func TestCollectActiveRunsReturnsErrorOnServerError(t *testing.T) {
 	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
 
 	assert.Error(t, CollectActiveRuns(t.Context(), c))
+}
+
+func TestCollectActiveRunsTracksMaxElapsedPerGroup(t *testing.T) {
+	now := time.Now()
+	// Two STARTED runs for job_a: one that entered STARTED 5 minutes ago,
+	// one that entered STARTED 30 seconds ago (per updateTime, which
+	// Dagster only bumps on a run-level status transition — see
+	// elapsedSince). The group's elapsed time should reflect the older
+	// (longer-running) one, not the newer one or their sum/average.
+	olderUpdate := now.Add(-5 * time.Minute).Unix()
+	newerUpdate := now.Add(-30 * time.Second).Unix()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		body := fmt.Sprintf(`{
+			"data": {
+				"runsOrError": {
+					"__typename": "Runs",
+					"results": [
+						{"runId": "run_older", "jobName": "job_a", "status": "STARTED", "updateTime": %d, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "loc_a"}},
+						{"runId": "run_newer", "jobName": "job_a", "status": "STARTED", "updateTime": %d, "repositoryOrigin": {"repositoryName": "__repository__", "repositoryLocationName": "loc_a"}}
+					]
+				}
+			}
+		}`, olderUpdate, newerUpdate)
+		_, err := w.Write([]byte(body))
+		if err != nil {
+			t.Fatalf("failed to write mock response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+	require.NoError(t, CollectActiveRuns(t.Context(), c))
+
+	agg := c.activeRunAggregates[ActiveRunKey{JobName: "job_a", LocationName: "loc_a", Status: "STARTED"}]
+	assert.Equal(t, 2, agg.count)
+	assert.InDelta(t, 300, agg.maxElapsed, 5, "should report the older run's elapsed time (~5m), not the newer one's (~30s)")
+
+	ch := make(chan prometheus.Metric, 16)
+	go func() {
+		reflectActiveRuns(c, ch)
+		close(ch)
+	}()
+
+	var sawCount, sawDuration bool
+	for m := range ch {
+		var dm dto.Metric
+		require.NoError(t, m.Write(&dm))
+		labels := make(map[string]string)
+		for _, l := range dm.GetLabel() {
+			labels[l.GetName()] = l.GetValue()
+		}
+		if labels["job_name"] != "job_a" || labels["status"] != "started" {
+			continue
+		}
+		desc := m.Desc().String()
+		switch {
+		case strings.Contains(desc, "dagster_active_run_duration_seconds"):
+			sawDuration = true
+			assert.InDelta(t, 300, dm.GetGauge().GetValue(), 5)
+		case strings.Contains(desc, "dagster_active_runs"):
+			sawCount = true
+			assert.Equal(t, float64(2), dm.GetGauge().GetValue())
+		}
+	}
+	assert.True(t, sawCount, "expected a dagster_active_runs series")
+	assert.True(t, sawDuration, "expected a dagster_active_run_duration_seconds series")
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -22,9 +22,10 @@ type DagsterCollector struct {
 	scrapeErrorsCounter       *prometheus.CounterVec
 	codeLocationLoadErrorDesc *prometheus.Desc
 	lastRunDurationDesc       *prometheus.Desc
+	activeRunDurationDesc     *prometheus.Desc
 
 	mutex                   sync.Mutex
-	activeRunsCounts        map[ActiveRunKey]int
+	activeRunAggregates     map[ActiveRunKey]activeRunAggregate
 	processedRuns           *ttlcache.Cache[string, struct{}]
 	lookbackWindow          time.Duration
 	knownJobs               map[JobKey]struct{}
@@ -116,6 +117,12 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"job_name", "location", "status"},
 			nil,
 		),
+		activeRunDurationDesc: prometheus.NewDesc(
+			"dagster_active_run_duration_seconds",
+			"Elapsed time (now - creationTime) of the longest-waiting/longest-running active run per job and status; 0 if there are no active runs in that group",
+			[]string{"job_name", "location", "status"},
+			nil,
+		),
 		processedRuns:                cache,
 		lookbackWindow:               lookbackWindow,
 		lastRunStatus:                make(map[JobKey]lastRunEntry),
@@ -134,6 +141,7 @@ func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.lastScrapeSuccessDesc
 	ch <- c.codeLocationLoadErrorDesc
 	ch <- c.lastRunDurationDesc
+	ch <- c.activeRunDurationDesc
 	c.completedRunsCounter.Describe(ch)
 	c.scrapeErrorsCounter.Describe(ch)
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -21,9 +21,9 @@ func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
 		descCount++
 	}
 	// activeRunsDesc, lastRunStatusDesc, scrapeDurationDesc, lastScrapeSuccessDesc,
-	// codeLocationLoadErrorDesc, lastRunDurationDesc, plus one each from
-	// completedRunsCounter and scrapeErrorsCounter.
-	assert.Equal(t, 8, descCount)
+	// codeLocationLoadErrorDesc, lastRunDurationDesc, activeRunDurationDesc,
+	// plus one each from completedRunsCounter and scrapeErrorsCounter.
+	assert.Equal(t, 9, descCount)
 
 	c.RecordScrapeResult("active_runs", 10*time.Millisecond, nil)
 


### PR DESCRIPTION
## What

Adds `dagster_active_run_duration_seconds{job_name,location,status}`, a gauge reporting elapsed time of the longest-waiting/longest-running active run per job/location/status group (the max across the group, not a sum/average — `run_id` isn't a label since that would grow unbounded, per the issue's suggestion).

`CollectActiveRuns` now aggregates into `activeRunAggregate{count, maxElapsed}` per `ActiveRunKey` instead of a bare count, and `reflectActiveRuns` emits both `dagster_active_runs` and the new duration gauge from a single locked pass over the aggregate map (same pattern as the earlier `lastRunStatus`/`lastRunDuration` merge — they're two views of the same per-key data, so iterating/locking twice would be pure overhead).

Also:
- Adds a "Active Run Duration by Job" panel to the Grafana dev dashboard.
- Adds a `grafana-lint` CI job that validates the dashboard JSON and checks it's `jq`-formatted (there was no CI coverage for it at all before).

## Why

Closes #30.

**Elapsed-time basis (`updateTime`, not `creationTime`):** the first version of this used `now - creationTime` for every active status, but that's wrong for `started` — `creationTime` is fixed at when the run was *queued*, so it would fold the queued+starting wait time into the "how long has it been running" number for `started` runs. I checked Dagster's storage layer (`SqlRunStorage.handle_run_event` / `EVENT_TYPE_TO_PIPELINE_RUN_STATUS` in `dagster/_core/storage/runs/sql_run_storage.py` and `dagster/_core/events/__init__.py`): a run's `updateTime` is bumped *only* on a run-level status-transition event (`RUN_ENQUEUED`/`RUN_STARTING`/`RUN_START`/...), never on step-level events (op start/success, asset materializations, ...). So `updateTime` is exactly "when this run entered its current status" for every active status, with no need to special-case `started` with a separate field.

**Snapshot limitation:** `CollectActiveRuns` re-queries "what's active right now" every scrape rather than incrementally, so a run that passes through `queued`/`starting`/`started` and finishes entirely between two scrapes is never observed in any active status — this already applied to `dagster_active_runs` and now applies to this metric too. Documented in the README metrics table.

## QA

- `go build ./...`, `go vet ./...`, `go test ./... -race`, `gofmt -l .`, `golangci-lint run ./...` all pass.
- `uvx ruff check .` passes (no Python touched, but still green).
- `jq empty` + `diff <(jq . file) file` passes on the dashboard JSON (what the new CI job checks).
- New test `TestCollectActiveRunsTracksMaxElapsedPerGroup`: two `STARTED` runs in the same group with different `updateTime`s, asserts the group reports the older (longer-running) one's elapsed time, not the newer one's or a sum/average; also checks both `dagster_active_runs` and `dagster_active_run_duration_seconds` come out of one `reflectActiveRuns` call.
- Updated the zero-fill test to check `activeRunAggregate{}`'s zero value on both fields.
- Updated `collector_test.go`'s `Describe`/`Collect` desc-count assertion (8 → 9) for the new `Desc`.
- Manually verified end-to-end against a real Dagster 1.13.15 dev instance:
  - Confirmed via GraphQL introspection that `updateTime` behaves as expected — matches `creationTime` while `QUEUED`, updates on entering `STARTING`, and exactly equals `startTime` on entering `STARTED`.
  - Launched a real job run and watched `/metrics` track `dagster_active_run_duration_seconds` correctly through `queued`→`starting`→`started`, dropping back to all-zero once it completed.
  - Hit a case where the job's concurrency limit left one run `queued` while another was `started` simultaneously — confirmed both groups tracked independently and correctly (`queued` ~3.7s, `started` ~21.7s at the same scrape).
  - Spun up Prometheus + Grafana against the same exporter and confirmed the new dashboard panel queries return the expected real data and the dashboard provisions without error.
- Updated README: new metric row (including the `updateTime`-vs-`creationTime` rationale and the snapshot-limitation caveat, added to `dagster_active_runs`' row too since it already applied there), Example output, a new PromQL example, the Roadmap checkbox, and a new "reformat the dashboard JSON" note.

## Ref
Closes #30