### PR TITLE
Add dagster_exporter_build_info metric

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,3 +46,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -96,13 +96,14 @@ The per-job metrics are labeled with `job_name` and `location` (the Dagster code
 
 ### Exporter self-health
 
-These report on the exporter itself — whether its own scrapes of Dagster are succeeding — rather than on Dagster's run state. All three are labeled `collector`, one of `job_locations`, `active_runs`, `completed_runs`, or `code_location_status` (the four concurrent collectors described in [Architecture](#architecture)).
+These report on the exporter itself, rather than on Dagster's run state. The first three are about whether its own scrapes of Dagster are succeeding, and are labeled `collector`, one of `job_locations`, `active_runs`, `completed_runs`, or `code_location_status` (the four concurrent collectors described in [Architecture](#architecture)).
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
 | `dagster_exporter_scrape_duration_seconds` | Gauge | `collector` | Duration of that collector's most recent scrape. |
 | `dagster_exporter_last_scrape_success` | Gauge | `collector` | `1` if that collector's most recent scrape succeeded, `0` if it failed. |
 | `dagster_exporter_scrape_errors_total` | Counter | `collector` | Total number of failed scrapes for that collector, since the exporter started. |
+| `dagster_exporter_build_info` | Gauge | `version`, `commit` | Always `1`; the same `kube_pod_info`-style pattern as `dagster_last_run_info`, but for the exporter binary itself (same idiom as `node_exporter`'s `node_exporter_build_info`). Useful for spotting pods still running an old version after a fleet rollout (e.g. via the Helm chart). The published container image sets real values at build time; a plain `go build`/`go install` reports `version="dev"`, `commit="unknown"`. |
 
 ### Example output
 
@@ -277,6 +278,7 @@ CI (`.github/workflows/ci.yml`) runs all of the above — Go steps only when `.g
 - [x] Latest completed run duration
 - [x] Running duration (longest-running active run per job)
 - [x] Exporter self-health metrics (scrape duration/errors)
+- [x] Exporter build info metric
 - [x] Code location load error visibility
 - [ ] Schedule tick status
 - [ ] Sensor / asset materialization metrics

--- a/docker/exporter.Dockerfile
+++ b/docker/exporter.Dockerfile
@@ -2,6 +2,12 @@ FROM golang:1.26-alpine AS builder
 
 ENV CGO_ENABLED=0
 
+# Surfaced as dagster_exporter_build_info (see internal/version). Left at
+# their defaults for a plain `docker build` (e.g. local dev via
+# docker-compose); docker-publish.yml passes real values on release builds.
+ARG VERSION=dev
+ARG COMMIT=unknown
+
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -10,7 +16,10 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY internal/ internal/
 
-RUN go build -ldflags="-w -s" -o /app/exporter ./cmd/exporter
+RUN go build -ldflags="-w -s \
+    -X github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/version.Version=${VERSION} \
+    -X github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/version.Commit=${COMMIT}" \
+    -o /app/exporter ./cmd/exporter
 
 FROM alpine:3.20
 

--- a/internal/server/build_info.go
+++ b/internal/server/build_info.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/version"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// newBuildInfoGauge returns a dagster_exporter_build_info gauge, always 1,
+// with the running binary's version/commit carried as labels — the same
+// pattern as node_exporter's node_exporter_build_info. Separate from
+// DagsterCollector since it isn't derived from scraping Dagster: it's a
+// static fact about the process, set once and never updated.
+func newBuildInfoGauge(ver, commit string) prometheus.Collector {
+	g := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "dagster_exporter_build_info",
+			Help: "Always 1; version/commit of the running exporter binary are carried as labels",
+		},
+		[]string{"version", "commit"},
+	)
+	g.WithLabelValues(ver, commit).Set(1)
+	return g
+}
+
+func registerBuildInfo() {
+	prometheus.MustRegister(newBuildInfoGauge(version.Version, version.Commit))
+}

--- a/internal/server/build_info_test.go
+++ b/internal/server/build_info_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBuildInfoGaugeReportsVersionAndCommit(t *testing.T) {
+	g := newBuildInfoGauge("v1.2.3", "abc1234")
+
+	ch := make(chan prometheus.Metric, 4)
+	g.Collect(ch)
+	close(ch)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	require.Len(t, metrics, 1)
+
+	var dm dto.Metric
+	require.NoError(t, metrics[0].Write(&dm))
+	assert.Equal(t, float64(1), dm.GetGauge().GetValue())
+
+	labels := make(map[string]string)
+	for _, l := range dm.GetLabel() {
+		labels[l.GetName()] = l.GetValue()
+	}
+	assert.Equal(t, "v1.2.3", labels["version"])
+	assert.Equal(t, "abc1234", labels["commit"])
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ func RunServer(ctx context.Context, config *config.Config) {
 	portSuffix := fmt.Sprintf(":%d", config.Port)
 	c := collector.NewDagsterCollector(ctx, config.DagsterGraphQLEndpoint, config.LookbackWindow, config.CacheTTL, config.RunsPageSize, config.RunsUpdatedAfterSafetyMargin)
 	prometheus.MustRegister(c)
+	registerBuildInfo()
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,20 @@
+// Package version holds the exporter's own version/commit, so they can be
+// surfaced as the dagster_exporter_build_info metric (see
+// internal/server/build_info.go) — the same idiom as node_exporter's
+// node_exporter_build_info: an always-1 gauge carrying the values as
+// labels, useful for spotting pods still running an old version after a
+// fleet rollout (e.g. via the Helm chart).
+package version
+
+// Version and Commit default to these placeholders for a plain `go build`/
+// `go test`/`go install` without the -ldflags below — that's expected for
+// local development. The published container image sets them at build time
+// via:
+//
+//	go build -ldflags "-X .../internal/version.Version=$VERSION -X .../internal/version.Commit=$COMMIT"
+//
+// (see docker/exporter.Dockerfile and .github/workflows/docker-publish.yml).
+var (
+	Version = "dev"
+	Commit  = "unknown"
+)


### PR DESCRIPTION
## What

Adds `dagster_exporter_build_info{version,commit}`, an always-`1` gauge carrying the running exporter's version/commit as labels — the standard Prometheus exporter idiom (`node_exporter`'s `node_exporter_build_info`, and common in Airflow/Prefect community exporters too).

- New `internal/version` package holds `Version`/`Commit` vars, defaulting to `"dev"`/`"unknown"`.
- `internal/server/build_info.go` builds and registers the gauge (`registerBuildInfo()`, called from `RunServer`) separately from `DagsterCollector`, since it isn't derived from scraping Dagster — it's a static fact about the process, set once at startup.
- Real values are injected at build time via `-ldflags -X`, wired through:
  - `docker/exporter.Dockerfile`: new `VERSION`/`COMMIT` build `ARG`s, defaulting to the same `"dev"`/`"unknown"` placeholders so a plain `docker build` (e.g. the local `docker-compose` dev stack) is unaffected.
  - `.github/workflows/docker-publish.yml`: passes the real tag (`github.ref_name`) and commit (`github.sha`) as `build-args` on release builds, so the published GHCR image carries real values.

## Why

Towards #40. Per the issue, this becomes more useful now that the Helm chart (#33) exists and multiple exporter pods might be running across a fleet — makes it easy to spot pods still running an old version after a rollout.

## QA

- `go build ./...`, `go vet ./...`, `go test ./... -race`, `gofmt -l .`, `golangci-lint run ./...` all pass.
- New test `TestNewBuildInfoGaugeReportsVersionAndCommit` checks the gauge reports value `1` with the given version/commit as labels.
- Manually verified with a local `docker build`:
  - No `--build-arg`: `/metrics` reports `dagster_exporter_build_info{commit="unknown",version="dev"} 1`.
  - `--build-arg VERSION=v9.9.9 --build-arg COMMIT=deadbeef`: reports `dagster_exporter_build_info{commit="deadbeef",version="v9.9.9"} 1`.
- Updated README: new row in the "Exporter self-health" section (with a note on how it's populated for the container image vs. `go build`/`go install`), and the Roadmap checkbox.
- **Not yet verified**: the `docker-publish.yml` build-args path only runs on an actual `v*.*.*` tag push, so it hasn't been exercised for real yet. #40 is intentionally left open until the next tagged release confirms the published GHCR image actually carries the real version/commit (see comment on the issue).

## Ref
#40 (left open — see above)