### PR TITLE
Add dagster_sensor_status and dagster_sensor_last_tick_status metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Because scraping (writing state) and metrics rendering (reading state) are decou
 
 The four collectors (definitions roster, active runs, completed runs, code-location load status) run concurrently on every scrape — each locks `DagsterCollector`'s own mutex only around its own critical section, so they don't block each other or `/metrics`. The code-location load status collector is intentionally independent of the definitions-roster one: `repositoriesOrError` (used for the roster) silently omits a code location that fails to load rather than erroring out, so a separate `workspaceOrError` query is needed to detect that failure at all — see `dagster_code_location_load_error` below. `dagster_run_queue_concurrency_key_backlog` (below) is folded into the active-runs collector instead of getting its own: it only needs QUEUED runs' tags, which that collector already fetches on every page, so a separate query would just re-fetch the same runs a second time for no reason.
 
-The definitions-roster collector is named for what it actually fetches: `repositoriesOrError`, which exposes jobs and schedules as independent sibling fields on Dagster's `Repository` type (not schedules-reachable-only-via-jobs), so both come back from one query. It builds the known-jobs set used to prune/seed completed-run counters and last-run status (unchanged since before schedules existed), plus each schedule's enabled/disabled state and most recent tick (`dagster_schedule_status`/`dagster_schedule_last_tick_status`).
+The definitions-roster collector is named for what it actually fetches: `repositoriesOrError`, which exposes jobs, schedules, and sensors as independent sibling fields on Dagster's `Repository` type (not reachable only via jobs), so all three come back from one query. It builds the known-jobs set used to prune/seed completed-run counters and last-run status (unchanged since before schedules/sensors existed), plus each schedule's and sensor's enabled/disabled state and most recent tick (`dagster_schedule_status`/`dagster_schedule_last_tick_status`, `dagster_sensor_status`/`dagster_sensor_last_tick_status`). Dagster's `Schedule.scheduleState` and `Sensor.sensorState` are both the same `InstigationState` type under the hood, so the two pairs of metrics are structurally identical.
 
 Fetching completed runs is incremental, not a full re-scan every cycle: after the first scrape (which backfills `LOOKBACK_WINDOW_MINUTES`), each subsequent scrape only asks Dagster for runs updated since the last-seen watermark (minus a small safety margin, to tolerate a run's DB write committing slightly after its `updateTime`). Any single fetch — the initial backfill or an unusually large batch of updates — pages through `runsOrError` via cursor (`RUNS_PAGE_SIZE` per page) and folds each page into the in-memory counters as it arrives, rather than buffering the full result set in memory first.
 
@@ -98,6 +98,8 @@ The per-job metrics are labeled with `job_name` and `location` (the Dagster code
 | `dagster_run_queue_concurrency_key_backlog` | Gauge | `concurrency_key` | Number of runs currently `QUEUED` because of a tag-based run-queue concurrency limit (`dagster.yaml`'s `concurrency.runs.tag_concurrency_limits`), per `dagster/concurrency_key` tag value. Not job/location-scoped, since a concurrency key can be shared across jobs. Note: Dagster's `instance.concurrencyLimits` GraphQL query looks like it would answer this directly, but it doesn't — it's backed by a separate op/step "pool" concurrency store and reports `0` for run-level tag-based backlog regardless of how many runs are actually queued behind a key, so this is computed by reading each `QUEUED` run's own tags instead. A concurrency key is zero-filled (not dropped) once its backlog clears, for the same reason as `dagster_active_runs`: a missing series and a `0` mean different things. |
 | `dagster_schedule_status` | Gauge | `schedule_name`, `location`, `status` | Always `1`; an "info" metric (same pattern as `dagster_last_run_info`) reporting whether a schedule is currently turned on (`running`) or off (`stopped`) in Dagster. Refetched from scratch on every scrape, unlike `dagster_last_run_info` — a removed schedule just isn't in the response anymore, no pruning needed. |
 | `dagster_schedule_last_tick_status` | Gauge | `schedule_name`, `location`, `status` | Always `1`; status of a schedule's most recently observed tick (`started`, `skipped`, `success`, or `failure`). A schedule that has never ticked yet has no series — no seeded value, same rationale as `dagster_last_run_info` for a job that's never run. |
+| `dagster_sensor_status` | Gauge | `sensor_name`, `location`, `status` | Same as `dagster_schedule_status`, for sensors: `running`/`stopped`. |
+| `dagster_sensor_last_tick_status` | Gauge | `sensor_name`, `location`, `status` | Same as `dagster_schedule_last_tick_status`, for sensors. Note a sensor tick that decides not to launch anything is `skipped`, not a lack of data — Dagster's sensor daemon evaluates on a fixed interval regardless of whether there's anything to do, so `skipped` is a normal, common outcome, not necessarily a problem. |
 
 ### Exporter self-health
 
@@ -135,6 +137,10 @@ dagster_run_queue_concurrency_key_backlog{concurrency_key="heavy_limit"} 3
 dagster_schedule_status{schedule_name="daily_refresh",location="dev-dagster-workspace",status="running"} 1
 
 dagster_schedule_last_tick_status{schedule_name="daily_refresh",location="dev-dagster-workspace",status="success"} 1
+
+dagster_sensor_status{sensor_name="new_file_sensor",location="dev-dagster-workspace",status="running"} 1
+
+dagster_sensor_last_tick_status{sensor_name="new_file_sensor",location="dev-dagster-workspace",status="skipped"} 1
 ```
 
 ### PromQL examples
@@ -171,6 +177,13 @@ dagster_run_queue_concurrency_key_backlog > 0
 dagster_schedule_status{status="running"} == 1
 and on (schedule_name, location)
 dagster_schedule_last_tick_status{status!="success"} == 1
+
+# Sensors that are turned on but whose last tick was a hard failure
+# (unlike schedules, "skipped" is a normal, common outcome for a sensor —
+# it just means nothing matched that evaluation — so this only flags failure)
+dagster_sensor_status{status="running"} == 1
+and on (sensor_name, location)
+dagster_sensor_last_tick_status{status="failure"} == 1
 ```
 
 ## Endpoints
@@ -266,9 +279,9 @@ dagster_code_location_load_error{location="broken_location"} 1
 dagster_code_location_load_error{location="dev-dagster-location"} 0
 ```
 
-### Testing schedule tick status
+### Testing schedule/sensor tick status
 
-Unlike the broken-code-location fixture above, this one isn't opt-in: `dev/dagster_workspace/job.py` defines `quick_job_schedule` (cron `* * * * *`, `default_status=DefaultScheduleStatus.RUNNING`) against a near-instant job, so the standard dev stack (`docker compose up`) starts ticking it automatically — no extra setup needed to see `dagster_schedule_status`/`dagster_schedule_last_tick_status` report real data within about a minute of startup.
+Unlike the broken-code-location fixture above, these aren't opt-in: `dev/dagster_workspace/job.py` defines `quick_job_schedule` (cron `* * * * *`, `default_status=DefaultScheduleStatus.RUNNING`) and `quick_job_sensor` (`minimum_interval_seconds=30`, `default_status=DefaultSensorStatus.RUNNING`, always returns a `SkipReason`) against a near-instant job, so the standard dev stack (`docker compose up`) starts ticking both automatically — no extra setup needed to see `dagster_schedule_status`/`dagster_schedule_last_tick_status`/`dagster_sensor_status`/`dagster_sensor_last_tick_status` report real data within about a minute of startup.
 
 ### Running tests
 
@@ -306,7 +319,8 @@ CI (`.github/workflows/ci.yml`) runs all of the above — Go steps only when `.g
 - [x] Code location load error visibility
 - [x] Run queue concurrency-key backlog
 - [x] Schedule tick status
-- [ ] Sensor / asset materialization metrics
+- [x] Sensor tick status
+- [ ] Asset materialization metrics
 - [x] Published container image / tagged release
 - [x] Helm chart for Kubernetes deployment
 

--- a/dev/dagster_workspace/definitions.py
+++ b/dev/dagster_workspace/definitions.py
@@ -1,5 +1,5 @@
 from dagster import Definitions
 
-from dev.dagster_workspace.job import jobs, schedules
+from dev.dagster_workspace.job import jobs, schedules, sensors
 
-defs = Definitions(jobs=jobs, schedules=schedules)
+defs = Definitions(jobs=jobs, schedules=schedules, sensors=sensors)

--- a/dev/dagster_workspace/job.py
+++ b/dev/dagster_workspace/job.py
@@ -1,6 +1,15 @@
 import time
 
-from dagster import DefaultScheduleStatus, ScheduleDefinition, job, op
+from dagster import (
+    DefaultScheduleStatus,
+    DefaultSensorStatus,
+    ScheduleDefinition,
+    SensorEvaluationContext,
+    SkipReason,
+    job,
+    op,
+    sensor,
+)
 
 
 @op
@@ -47,3 +56,18 @@ every_minute_schedule = ScheduleDefinition(
 )
 
 schedules = [every_minute_schedule]
+
+
+# default_status=RUNNING, same rationale as the schedule above. Always
+# skips (rather than launching quick_job) so its ticks are deterministically
+# SKIPPED — a distinct outcome from the schedule's SUCCESS ticks, useful for
+# exercising dagster_sensor_status/dagster_sensor_last_tick_status with more
+# than one status value present.
+@sensor(job=quick_job, minimum_interval_seconds=30, default_status=DefaultSensorStatus.RUNNING)
+def quick_job_sensor(context: SensorEvaluationContext):
+    return SkipReason(
+        "dev fixture: intentionally always skips, for exercising dagster_sensor_last_tick_status"
+    )
+
+
+sensors = [quick_job_sensor]

--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -398,6 +398,150 @@
       }
     },
     {
+      "title": "Sensor Status",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "dagster_sensor_status",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "running": {
+                        "text": "Running",
+                        "color": "green"
+                      },
+                      "stopped": {
+                        "text": "Stopped",
+                        "color": "light-grey"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 45
+      }
+    },
+    {
+      "title": "Sensor Last Tick Status",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "dagster_sensor_last_tick_status",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "success": {
+                        "text": "Success",
+                        "color": "green"
+                      },
+                      "failure": {
+                        "text": "Failure",
+                        "color": "red"
+                      },
+                      "skipped": {
+                        "text": "Skipped",
+                        "color": "light-grey"
+                      },
+                      "started": {
+                        "text": "Started",
+                        "color": "yellow"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      }
+    },
+    {
       "title": "Broken Code Locations",
       "type": "stat",
       "targets": [

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -26,12 +26,16 @@ type DagsterCollector struct {
 	concurrencyKeyBacklogDesc *prometheus.Desc
 	scheduleStatusDesc        *prometheus.Desc
 	scheduleTickStatusDesc    *prometheus.Desc
+	sensorStatusDesc          *prometheus.Desc
+	sensorTickStatusDesc      *prometheus.Desc
 
 	mutex                   sync.Mutex
 	activeRunAggregates     map[ActiveRunKey]activeRunAggregate
 	concurrencyKeyBacklog   map[string]int
 	scheduleStatus          map[ScheduleKey]string
 	scheduleTickStatus      map[ScheduleKey]scheduleTickEntry
+	sensorStatus            map[SensorKey]string
+	sensorTickStatus        map[SensorKey]sensorTickEntry
 	processedRuns           *ttlcache.Cache[string, struct{}]
 	lookbackWindow          time.Duration
 	knownJobs               map[JobKey]struct{}
@@ -147,6 +151,18 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"schedule_name", "location", "status"},
 			nil,
 		),
+		sensorStatusDesc: prometheus.NewDesc(
+			"dagster_sensor_status",
+			"Whether a sensor is currently turned on (value is always 1; status is carried in the status label, one of running/stopped)",
+			[]string{"sensor_name", "location", "status"},
+			nil,
+		),
+		sensorTickStatusDesc: prometheus.NewDesc(
+			"dagster_sensor_last_tick_status",
+			"Status of a sensor's most recent tick (value is always 1; status is carried in the status label, one of started/skipped/success/failure)",
+			[]string{"sensor_name", "location", "status"},
+			nil,
+		),
 		processedRuns:                cache,
 		lookbackWindow:               lookbackWindow,
 		lastRunStatus:                make(map[JobKey]lastRunEntry),
@@ -169,6 +185,8 @@ func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.concurrencyKeyBacklogDesc
 	ch <- c.scheduleStatusDesc
 	ch <- c.scheduleTickStatusDesc
+	ch <- c.sensorStatusDesc
+	ch <- c.sensorTickStatusDesc
 	c.completedRunsCounter.Describe(ch)
 	c.scrapeErrorsCounter.Describe(ch)
 }
@@ -181,6 +199,8 @@ func (c *DagsterCollector) Collect(ch chan<- prometheus.Metric) {
 	reflectConcurrencyKeyBacklog(c, ch)
 	reflectScheduleStatus(c, ch)
 	reflectScheduleTickStatus(c, ch)
+	reflectSensorStatus(c, ch)
+	reflectSensorTickStatus(c, ch)
 	c.completedRunsCounter.Collect(ch)
 	c.scrapeErrorsCounter.Collect(ch)
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -23,8 +23,9 @@ func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
 	// activeRunsDesc, lastRunStatusDesc, scrapeDurationDesc, lastScrapeSuccessDesc,
 	// codeLocationLoadErrorDesc, lastRunDurationDesc, activeRunDurationDesc,
 	// concurrencyKeyBacklogDesc, scheduleStatusDesc, scheduleTickStatusDesc,
-	// plus one each from completedRunsCounter and scrapeErrorsCounter.
-	assert.Equal(t, 12, descCount)
+	// sensorStatusDesc, sensorTickStatusDesc, plus one each from
+	// completedRunsCounter and scrapeErrorsCounter.
+	assert.Equal(t, 14, descCount)
 
 	c.RecordScrapeResult("active_runs", 10*time.Millisecond, nil)
 

--- a/internal/collector/definitions_roster.go
+++ b/internal/collector/definitions_roster.go
@@ -23,13 +23,15 @@ func buildKnownJobs(resp *GraphQLDefinitionsRosterResponse) map[JobKey]struct{} 
 	return known
 }
 
-// CollectDefinitionsRoster fetches the full jobs+schedules roster in one
-// GraphQL call (repositoriesOrError exposes both as sibling fields on
-// Repository) and updates every piece of exporter state derived from "what
-// currently exists": known jobs (for completed-run counter/last-run-status
-// pruning/seeding, unchanged from before schedules were added), and known
-// schedules with their current enabled/disabled status and most recent
-// tick (see buildScheduleState in schedules.go).
+// CollectDefinitionsRoster fetches the full jobs+schedules+sensors roster
+// in one GraphQL call (repositoriesOrError exposes all three as sibling
+// fields on Repository) and updates every piece of exporter state derived
+// from "what currently exists": known jobs (for completed-run
+// counter/last-run-status pruning/seeding, unchanged from before
+// schedules/sensors were added), known schedules with their current
+// enabled/disabled status and most recent tick (see buildScheduleState in
+// schedules.go), and the same for sensors (see buildSensorState in
+// sensors.go).
 func CollectDefinitionsRoster(ctx context.Context, c *DagsterCollector) error {
 	req := getDefinitionsRosterRequest()
 
@@ -41,6 +43,7 @@ func CollectDefinitionsRoster(ctx context.Context, c *DagsterCollector) error {
 
 	knownJobs := buildKnownJobs(resp)
 	scheduleStatus, scheduleTickStatus := buildScheduleState(resp)
+	sensorStatus, sensorTickStatus := buildSensorState(resp)
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -48,6 +51,8 @@ func CollectDefinitionsRoster(ctx context.Context, c *DagsterCollector) error {
 	c.knownJobs = knownJobs
 	c.scheduleStatus = scheduleStatus
 	c.scheduleTickStatus = scheduleTickStatus
+	c.sensorStatus = sensorStatus
+	c.sensorTickStatus = sensorTickStatus
 
 	pruneCompletedRunsCounter(c, knownJobs)
 	seedCompletedRunsCounter(c, knownJobs)

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -160,10 +160,12 @@ func getRuns(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoin
 // GraphQLDefinitionsRosterResponse is the shape of repositoriesOrError used
 // to build the exporter's view of "what exists": known jobs (JobKey,
 // pruning/seeding for completed-run counters and last-run status) and known
-// schedules with their most recent tick, in one fetch. Dagster's Repository
-// type exposes jobs and schedules as independent sibling fields (not
-// schedules-via-jobs), so both can be requested together without any
-// per-job/per-schedule follow-up query.
+// schedules/sensors with their most recent tick, in one fetch. Dagster's
+// Repository type exposes jobs, schedules, and sensors as independent
+// sibling fields (not reachable only via jobs), so all three can be
+// requested together without any per-job/per-schedule/per-sensor
+// follow-up query. Schedule.scheduleState and Sensor.sensorState are both
+// InstigationState under the hood, hence the identical status/ticks shape.
 type GraphQLDefinitionsRosterResponse struct {
 	Data struct {
 		RepositoriesOrError struct {
@@ -187,6 +189,16 @@ type GraphQLDefinitionsRosterResponse struct {
 						} `json:"ticks"`
 					} `json:"scheduleState"`
 				} `json:"schedules"`
+				Sensors []struct {
+					Name        string `json:"name"`
+					SensorState struct {
+						Status string `json:"status"`
+						Ticks  []struct {
+							Status    string  `json:"status"`
+							Timestamp float64 `json:"timestamp"`
+						} `json:"ticks"`
+					} `json:"sensorState"`
+				} `json:"sensors"`
 			} `json:"nodes"`
 			Message string   `json:"message"`
 			Stack   []string `json:"stack"`

--- a/internal/collector/queries/get_definitions_roster.graphql
+++ b/internal/collector/queries/get_definitions_roster.graphql
@@ -21,6 +21,16 @@ query GetDefinitionsRoster {
             }
           }
         }
+        sensors {
+          name
+          sensorState {
+            status
+            ticks(limit: 1) {
+              status
+              timestamp
+            }
+          }
+        }
       }
     }
     ... on PythonError {

--- a/internal/collector/sensors.go
+++ b/internal/collector/sensors.go
@@ -1,0 +1,85 @@
+package collector
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type SensorKey struct {
+	SensorName   string
+	LocationName string
+}
+
+// sensorTickEntry mirrors scheduleTickEntry: Sensor.sensorState is the same
+// InstigationState type as Schedule.scheduleState under the hood, so
+// sensors get an identical status/most-recent-tick tracking shape.
+type sensorTickEntry struct {
+	status    string
+	timestamp float64
+}
+
+// buildSensorState extracts each sensor's enabled/disabled status and most
+// recent tick from a definitions-roster response. Pulled out of
+// CollectDefinitionsRoster as its own pure function so it can be
+// unit-tested directly, without an HTTP mock — same pattern as
+// buildScheduleState.
+func buildSensorState(resp *GraphQLDefinitionsRosterResponse) (map[SensorKey]string, map[SensorKey]sensorTickEntry) {
+	status := make(map[SensorKey]string)
+	tickStatus := make(map[SensorKey]sensorTickEntry)
+
+	for _, repo := range resp.Data.RepositoriesOrError.Nodes {
+		for _, sensor := range repo.Sensors {
+			key := SensorKey{SensorName: sensor.Name, LocationName: repo.Location.Name}
+			status[key] = sensor.SensorState.Status
+
+			// ticks(limit: 1) returns the single most recent tick, newest
+			// first; a sensor that has never fired yet returns an empty
+			// list, and simply has no entry here (no seeded value — same
+			// rationale as dagster_last_run_info for a job that's never run).
+			if len(sensor.SensorState.Ticks) > 0 {
+				tick := sensor.SensorState.Ticks[0]
+				tickStatus[key] = sensorTickEntry{status: tick.Status, timestamp: tick.Timestamp}
+			}
+		}
+	}
+
+	return status, tickStatus
+}
+
+// reflectSensorStatus emits dagster_sensor_status: whether a sensor is
+// currently turned on (RUNNING) or off (STOPPED) in Dagster. Refetched in
+// full on every scrape, so c.sensorStatus is simply replaced wholesale each
+// time rather than merged — a removed sensor just isn't in the map anymore.
+func reflectSensorStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	for key, status := range c.sensorStatus {
+		ch <- prometheus.MustNewConstMetric(
+			c.sensorStatusDesc,
+			prometheus.GaugeValue,
+			1,
+			key.SensorName,
+			key.LocationName,
+			strings.ToLower(status),
+		)
+	}
+}
+
+// reflectSensorTickStatus emits dagster_sensor_last_tick_status for every
+// sensor that has ticked at least once. Same "no seeded value until the
+// first observation" behavior as dagster_last_run_info.
+func reflectSensorTickStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	for key, entry := range c.sensorTickStatus {
+		ch <- prometheus.MustNewConstMetric(
+			c.sensorTickStatusDesc,
+			prometheus.GaugeValue,
+			1,
+			key.SensorName,
+			key.LocationName,
+			strings.ToLower(entry.status),
+		)
+	}
+}

--- a/internal/collector/sensors_test.go
+++ b/internal/collector/sensors_test.go
@@ -1,0 +1,56 @@
+package collector
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSensorState(t *testing.T) {
+	var resp GraphQLDefinitionsRosterResponse
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"data": {
+			"repositoriesOrError": {
+				"__typename": "RepositoryConnection",
+				"nodes": [
+					{
+						"name": "repo",
+						"location": {"name": "loc_a"},
+						"jobs": [],
+						"sensors": [
+							{
+								"name": "ticked_sensor",
+								"sensorState": {
+									"status": "RUNNING",
+									"ticks": [
+										{"status": "SKIPPED", "timestamp": 200},
+										{"status": "SUCCESS", "timestamp": 100}
+									]
+								}
+							},
+							{
+								"name": "never_ticked_sensor",
+								"sensorState": {"status": "STOPPED", "ticks": []}
+							}
+						]
+					}
+				]
+			}
+		}
+	}`), &resp))
+
+	status, tickStatus := buildSensorState(&resp)
+
+	tickedKey := SensorKey{SensorName: "ticked_sensor", LocationName: "loc_a"}
+	assert.Equal(t, "RUNNING", status[tickedKey])
+	// ticks[0] (newest) should win, not ticks[1].
+	assert.Equal(t, "SKIPPED", tickStatus[tickedKey].status)
+	assert.Equal(t, float64(200), tickStatus[tickedKey].timestamp)
+
+	neverTickedKey := SensorKey{SensorName: "never_ticked_sensor", LocationName: "loc_a"}
+	assert.Equal(t, "STOPPED", status[neverTickedKey])
+	assert.NotContains(t, tickStatus, neverTickedKey,
+		"a sensor with an empty ticks list should have no tick-status entry, not a seeded zero value")
+}


### PR DESCRIPTION
## What

Companion to #31 (schedule tick status), symmetric implementation. Adds two new gauges, same "info" pattern as `dagster_schedule_status`/`dagster_schedule_last_tick_status`:
- `dagster_sensor_status{sensor_name,location,status}`: `running`/`stopped`.
- `dagster_sensor_last_tick_status{sensor_name,location,status}`: `started`/`skipped`/`success`/`failure`. No series for a sensor that's never ticked.

Confirmed via introspection that Dagster's `Sensor.sensorState` is the exact same `InstigationState` type as `Schedule.scheduleState`, and `Repository.sensors` is an independent sibling field to `jobs`/`schedules` (not job-scoped). So `get_definitions_roster.graphql` now also requests `sensors { name sensorState { status ticks(limit: 1) { status timestamp } } }` — still the one `repositoriesOrError` call `CollectDefinitionsRoster` already makes, no new query.

New `sensors.go` mirrors `schedules.go`: `SensorKey`, `sensorTickEntry`, `buildSensorState` (pure function, unit-tested via `json.Unmarshal`, no HTTP mock), `reflectSensorStatus`/`reflectSensorTickStatus`.

New dev fixture: `quick_job_sensor` (`minimum_interval_seconds=30`, `default_status=RUNNING`, always returns a `SkipReason`) — deterministic `SKIPPED` ticks, distinct from the schedule's `SUCCESS` ticks, so the dev stack exercises more than one status value out of the box.

## Why

Closes #39.

## QA

- `go build ./...`, `go vet ./...`, `go test ./... -race`, `gofmt -l .`, `golangci-lint run ./...` all pass.
- `uvx ruff check .` passes (new sensor fixture).
- `jq empty` + `diff <(jq . file) file` passes on the dashboard JSON.
- New `TestBuildSensorState`: a ticked sensor reports the newest tick (not an older one), a never-ticked sensor has status but no tick-status entry.
- Updated `collector_test.go`'s `Describe`/`Collect` desc-count assertion (12 → 14) for the two new `Desc`s.
- Manually verified end-to-end against a real Dagster 1.13.15 dev instance — including a real gotcha worth recording here too: after many restarts against the same `dagster_home` storage over the course of today's session, the `repositoriesOrError` path (which goes through Dagster's `RepositoryScopedBatchLoader`) started returning **empty ticks for the schedule specifically**, while the same query's sensor ticks and a direct `scheduleOrError` query both returned correct data. Traced it to `RepositoryScopedBatchLoader`'s `SCHEDULE_TICKS`/`SENSOR_TICKS` branches in Dagster's source and confirmed it's a batch-loader/storage inconsistency from accumulated dev-session state (repeated location reloads today), not a bug in this PR's code or a real Dagster issue — wiping `dev/dagster_home`'s storage and restarting clean resolved it and confirmed `repositoriesOrError`-sourced schedule ticks work correctly.
  - Confirmed `/metrics` reports `dagster_sensor_status{status="running"}` and `dagster_sensor_last_tick_status{status="skipped"}` alongside correct schedule/job/concurrency-backlog data (nothing regressed).
  - Spun up Prometheus + Grafana and confirmed the two new "Sensor Status"/"Sensor Last Tick Status" table panels render against real data.
- Updated README: two new metric rows, Architecture section, Example output, two new PromQL examples, the dev-stack testing note (renamed to cover both schedule and sensor), and the Roadmap checkbox (split the old combined "Sensor / asset materialization metrics" line so asset materialization stays correctly unchecked).

## Ref
Closes #39