### PR TITLE
Note open design questions on the asset materialization Roadmap line

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ CI (`.github/workflows/ci.yml`) runs all of the above — Go steps only when `.g
 - [x] Run queue concurrency-key backlog
 - [x] Schedule tick status
 - [x] Sensor tick status
-- [ ] Asset materialization metrics
+- [ ] Asset materialization metrics — several open design questions (metric shape, `asset_key` label encoding, collector structure); see [#56](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/56)
 - [x] Published container image / tagged release
 - [x] Helm chart for Kubernetes deployment
 


### PR DESCRIPTION
## What

Small doc-only change: adds a note + link to #56 on the README Roadmap's "Asset materialization metrics" line.

## Why

Unlike the other Roadmap items, this one has real open design questions recorded from investigation (query shape, the `assetMaterializations`-only-records-success gotcha, tentative metric design, how to encode the `asset_key` path as a label) rather than being a mostly-settled feature waiting to be implemented. Pointing at #56 makes that visible from the Roadmap itself.

## QA

Doc-only change, no code affected.

## Ref
Relates to #56