### PR TITLE
Add a kind-based e2e test for the Helm chart

### DIFF
--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -1,0 +1,88 @@
+name: Helm e2e (kind)
+
+# Complements helm-lint.yml: that catches template syntax errors, this
+# actually installs the chart into a real cluster against a real Dagster
+# instance and asserts the exporter gets real data — see issue #44.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "charts/**"
+      - "docker/**"
+      - "dev/dagster_workspace/**"
+      - "dev/kubernetes/**"
+      - ".github/workflows/helm-e2e.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "charts/**"
+      - "docker/**"
+      - "dev/dagster_workspace/**"
+      - "dev/kubernetes/**"
+      - ".github/workflows/helm-e2e.yml"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: helm/kind-action@v1
+        with:
+          cluster_name: dagster-exporter-e2e
+
+      - uses: azure/setup-helm@v5
+
+      - name: Build exporter and Dagster dev images
+        run: |
+          docker build -f docker/exporter.Dockerfile -t dagster-prometheus-exporter-e2e:exporter .
+          docker build -f docker/dagster-dev.Dockerfile -t dagster-prometheus-exporter-e2e:dagster .
+
+      - name: Load images into kind
+        run: |
+          kind load docker-image dagster-prometheus-exporter-e2e:exporter dagster-prometheus-exporter-e2e:dagster \
+            --name dagster-exporter-e2e
+
+      - name: Deploy the Dagster test fixture
+        run: |
+          kubectl apply -f dev/kubernetes/dagster-deployment.yaml
+          kubectl rollout status deployment/dagster --timeout=120s
+
+      - name: Install the exporter chart
+        run: |
+          helm install exporter-e2e charts/dagster-prometheus-exporter \
+            -f dev/kubernetes/exporter-e2e-values.yaml \
+            --wait --timeout=120s
+
+      - name: Assert /readyz and /metrics report real data
+        run: |
+          kubectl port-forward svc/exporter-e2e-dagster-prometheus-exporter 9101:9101 &
+          PORT_FORWARD_PID=$!
+          # Give the port-forward a moment to establish before curling.
+          for i in $(seq 1 10); do
+            curl -sf http://localhost:9101/healthz > /dev/null && break
+            sleep 1
+          done
+
+          echo "--- /readyz ---"
+          READYZ=$(curl -sf http://localhost:9101/readyz)
+          echo "$READYZ"
+          echo "$READYZ" | grep -q '"status":"OK"' || { echo "::error::exporter is not ready against the real Dagster instance"; exit 1; }
+
+          echo "--- /metrics (dagster_active_runs) ---"
+          METRICS=$(curl -sf http://localhost:9101/metrics)
+          echo "$METRICS" | grep '^dagster_active_runs{' || { echo "::error::no dagster_active_runs series found — exporter isn't reporting real data"; exit 1; }
+
+          kill "$PORT_FORWARD_PID"
+
+      - name: Dump pod state for debugging
+        if: failure()
+        run: |
+          kubectl get pods -o wide
+          echo "--- dagster ---"
+          kubectl describe deployment/dagster
+          kubectl logs deployment/dagster --tail=200
+          echo "--- exporter ---"
+          kubectl describe deployment/exporter-e2e-dagster-prometheus-exporter
+          kubectl logs deployment/exporter-e2e-dagster-prometheus-exporter --tail=200

--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -3,24 +3,21 @@ name: Helm e2e (kind)
 # Complements helm-lint.yml: that catches template syntax errors, this
 # actually installs the chart into a real cluster against a real Dagster
 # instance and asserts the exporter gets real data — see issue #44.
+#
+# Deliberately not a pull_request/push trigger: this also exercises the Go
+# server itself (the exporter image is always built fresh from the current
+# checkout, so any internal/**/cmd/** regression would show up here too),
+# not just chart/docker/dev changes — but a full kind cluster spin-up per
+# PR is heavy, and (being a real end-to-end test against real
+# infrastructure) more prone to transient flakiness than the unit-test-level
+# checks in ci.yml, so it isn't a required status check either. Scheduled +
+# on-demand instead: catches real regressions over time without slowing
+# down or blocking every PR.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "charts/**"
-      - "docker/**"
-      - "dev/dagster_workspace/**"
-      - "dev/kubernetes/**"
-      - ".github/workflows/helm-e2e.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "charts/**"
-      - "docker/**"
-      - "dev/dagster_workspace/**"
-      - "dev/kubernetes/**"
-      - ".github/workflows/helm-e2e.yml"
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
 
 jobs:
   e2e:

--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -71,8 +71,19 @@ jobs:
           echo "$READYZ" | grep -q '"status":"OK"' || { echo "::error::exporter is not ready against the real Dagster instance"; exit 1; }
 
           echo "--- /metrics (dagster_active_runs) ---"
-          METRICS=$(curl -sf http://localhost:9101/metrics)
-          echo "$METRICS" | grep '^dagster_active_runs{' || { echo "::error::no dagster_active_runs series found — exporter isn't reporting real data"; exit 1; }
+          # /readyz being OK only proves live Dagster connectivity, not that
+          # a background scrape has completed yet — the HTTP server and the
+          # scraper goroutine start concurrently (see internal/server.go),
+          # and the readinessProbe is /healthz (unconditionally 200), so the
+          # pod can be Ready before the first scrape lands. Poll for up to
+          # ~40s (a bit more than DAGSTER_SCRAPING_INTERVAL_SECONDS' 15s
+          # default) instead of asserting on a single sample.
+          for i in $(seq 1 20); do
+            METRICS=$(curl -sf http://localhost:9101/metrics)
+            echo "$METRICS" | grep -q '^dagster_active_runs{' && break
+            sleep 2
+          done
+          echo "$METRICS" | grep '^dagster_active_runs{' || { echo "::error::no dagster_active_runs series found after waiting for a scrape — exporter isn't reporting real data"; exit 1; }
 
           kill "$PORT_FORWARD_PID"
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,33 @@ dagster_code_location_load_error{location="dev-dagster-location"} 0
 
 Unlike the broken-code-location fixture above, these aren't opt-in: `dev/dagster_workspace/job.py` defines `quick_job_schedule` (cron `* * * * *`, `default_status=DefaultScheduleStatus.RUNNING`) and `quick_job_sensor` (`minimum_interval_seconds=30`, `default_status=DefaultSensorStatus.RUNNING`, always returns a `SkipReason`) against a near-instant job, so the standard dev stack (`docker compose up`) starts ticking both automatically — no extra setup needed to see `dagster_schedule_status`/`dagster_schedule_last_tick_status`/`dagster_sensor_status`/`dagster_sensor_last_tick_status` report real data within about a minute of startup.
 
+### Testing the Helm chart against a real Dagster (kind)
+
+`.github/workflows/helm-e2e.yml` installs the chart into a [kind](https://kind.sigs.k8s.io/) cluster against a real Dagster instance and asserts `/readyz`/`/metrics` report real data — `helm lint`/`helm template` (in `helm-lint.yml`) only catch template syntax errors, not "does this chart actually work." The Dagster instance is a plain Deployment+Service (`dev/kubernetes/dagster-deployment.yaml`, running the same `docker/dagster-dev.Dockerfile` image as the `docker compose` dev stack) — a CI-only test fixture, not part of the chart itself. Both it and the exporter image are always built from the local checkout, never pulled from a registry, so the test validates the current change, not whatever was last published.
+
+To reproduce locally:
+
+```sh
+kind create cluster --name dagster-exporter-e2e
+
+docker build -f docker/exporter.Dockerfile -t dagster-prometheus-exporter-e2e:exporter .
+docker build -f docker/dagster-dev.Dockerfile -t dagster-prometheus-exporter-e2e:dagster .
+kind load docker-image dagster-prometheus-exporter-e2e:exporter dagster-prometheus-exporter-e2e:dagster \
+  --name dagster-exporter-e2e
+
+kubectl apply -f dev/kubernetes/dagster-deployment.yaml
+kubectl rollout status deployment/dagster --timeout=120s
+
+helm install exporter-e2e charts/dagster-prometheus-exporter \
+  -f dev/kubernetes/exporter-e2e-values.yaml --wait --timeout=120s
+
+kubectl port-forward svc/exporter-e2e-dagster-prometheus-exporter 9101:9101 &
+curl http://localhost:9101/readyz
+curl http://localhost:9101/metrics
+
+kind delete cluster --name dagster-exporter-e2e
+```
+
 ### Running tests
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Release](https://img.shields.io/github/v/release/HirofumiTsuda/dagster-prometheus-exporter)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/releases/latest)
 [![CI](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml)
+[![Helm e2e](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/helm-e2e.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/helm-e2e.yml)
 [![codecov](https://codecov.io/gh/HirofumiTsuda/dagster-prometheus-exporter/graph/badge.svg)](https://codecov.io/gh/HirofumiTsuda/dagster-prometheus-exporter)
 [![CodeQL](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml)
 [![Go version](https://img.shields.io/github/go-mod/go-version/HirofumiTsuda/dagster-prometheus-exporter)](go.mod)
@@ -285,7 +286,9 @@ Unlike the broken-code-location fixture above, these aren't opt-in: `dev/dagster
 
 ### Testing the Helm chart against a real Dagster (kind)
 
-`.github/workflows/helm-e2e.yml` installs the chart into a [kind](https://kind.sigs.k8s.io/) cluster against a real Dagster instance and asserts `/readyz`/`/metrics` report real data — `helm lint`/`helm template` (in `helm-lint.yml`) only catch template syntax errors, not "does this chart actually work." The Dagster instance is a plain Deployment+Service (`dev/kubernetes/dagster-deployment.yaml`, running the same `docker/dagster-dev.Dockerfile` image as the `docker compose` dev stack) — a CI-only test fixture, not part of the chart itself. Both it and the exporter image are always built from the local checkout, never pulled from a registry, so the test validates the current change, not whatever was last published.
+`.github/workflows/helm-e2e.yml` (status: see the badge at the top of this README) installs the chart into a [kind](https://kind.sigs.k8s.io/) cluster against a real Dagster instance and asserts `/readyz`/`/metrics` report real data — `helm lint`/`helm template` (in `helm-lint.yml`) only catch template syntax errors, not "does this chart actually work," and since the exporter image is always built fresh from the current checkout, this also exercises the Go server itself, not just the chart. The Dagster instance is a plain Deployment+Service (`dev/kubernetes/dagster-deployment.yaml`, running the same `docker/dagster-dev.Dockerfile` image as the `docker compose` dev stack) — a CI-only test fixture, not part of the chart itself. Both it and the exporter image are always built from the local checkout, never pulled from a registry, so the test validates the current state of `main`, not whatever was last published.
+
+Runs daily on a schedule plus on-demand (`workflow_dispatch`), not on every push/PR: a full kind cluster spin-up is heavy to run per-PR, and being a real end-to-end test against real infrastructure, it's more prone to transient flakiness than the unit-test-level checks in `ci.yml` — so it's deliberately not a required status check either.
 
 To reproduce locally:
 

--- a/dev/kubernetes/dagster-deployment.yaml
+++ b/dev/kubernetes/dagster-deployment.yaml
@@ -1,0 +1,48 @@
+# CI-only test fixture for the Helm chart's kind-based e2e test (see
+# .github/workflows/helm-e2e.yml). A plain Deployment+Service running the
+# same dev/dagster-dev.Dockerfile image as the docker-compose dev stack —
+# deliberately not part of the Helm chart itself (this repo isn't taking on
+# maintaining a Dagster chart), just a stand-in Dagster instance for the
+# exporter chart to point at.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dagster
+  labels:
+    app: dagster
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dagster
+  template:
+    metadata:
+      labels:
+        app: dagster
+    spec:
+      containers:
+        - name: dagster
+          image: dagster-prometheus-exporter-e2e:dagster
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            # /graphql only accepts POST with a query body (GET returns 400
+            # "No GraphQL query found"); /server_info is dagster-webserver's
+            # actual lightweight healthcheck endpoint.
+            httpGet:
+              path: /server_info
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dagster
+spec:
+  selector:
+    app: dagster
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/dev/kubernetes/exporter-e2e-values.yaml
+++ b/dev/kubernetes/exporter-e2e-values.yaml
@@ -1,0 +1,10 @@
+# Helm values for the kind-based e2e test (.github/workflows/helm-e2e.yml).
+# Points the chart at the dev/kubernetes/dagster-deployment.yaml fixture and
+# at the locally-built, kind-loaded image (never pulled from a registry).
+image:
+  repository: dagster-prometheus-exporter-e2e
+  tag: exporter
+  pullPolicy: Never
+
+env:
+  DAGSTER_GRAPHQL_ENDPOINT: http://dagster.default.svc.cluster.local:3000/graphql


### PR DESCRIPTION
## What

`helm-lint.yml` (`helm lint`/`helm template`) only catches template syntax errors, not "does this chart actually deploy and run against a real Dagster." Adds a new workflow, `helm-e2e.yml`:

- `helm/kind-action` spins up a kind cluster.
- Builds the exporter and `dagster-dev` images from the local checkout (never pulled from a registry — this validates the current change, not whatever was last published) and `kind load docker-image`'s both.
- `dev/kubernetes/dagster-deployment.yaml`: a plain Deployment+Service running the same `docker/dagster-dev.Dockerfile` image as the `docker-compose` dev stack. Deliberately not part of the Helm chart itself (this repo isn't taking on maintaining a Dagster chart) — a CI-only test fixture, kept in `dev/` (not `.github/`) since it's a generic Kubernetes manifest with nothing kind-specific about it.
- `helm install` with `dev/kubernetes/exporter-e2e-values.yaml` (a real Helm values file, not inline `--set` flags — `image.pullPolicy: Never` is required since kind-loaded images aren't from a registry).
- Asserts `/readyz` and `/metrics` report real data from the real Dagster instance, not just that the pod started; dumps pod state on failure.

Also documents the whole flow (including how to reproduce it locally) in the main README's new "Testing the Helm chart against a real Dagster (kind)" section.

## Why

Closes #44.

Found dagster-webserver's actual healthcheck endpoint the hard way: `GET /graphql` returns `400` (`"No GraphQL query found in the request"`) — it only accepts `POST` with a query body. `/server_info` is what dagster-webserver itself exposes for this, and is what the Dagster fixture's `readinessProbe` uses.

## QA

- `go build ./...`, `go vet ./...`, `go test ./... -race`, `gofmt -l .`, `golangci-lint run ./...`, `uvx ruff check .`, `jq`-format check on the Grafana dashboard, and `helm lint --strict` all pass (none of this PR's changes touch Go/Python/Grafana, but re-ran to confirm nothing regressed).
- Verified the entire flow locally end-to-end with a real `kind` cluster before writing the workflow, matching every step: cluster creation, image build + load, fixture deploy (`kubectl rollout status` succeeded), `helm install --wait --timeout=120s` (succeeded), and the `/readyz`/`/metrics` assertions both passed against a real Dagster 1.13.15 instance running in-cluster.
- Along the way, confirmed the `readinessProbe` fix was necessary: the initial `GET /graphql` probe failed with `400`/connection-refused for the pod's first ~3 minutes; switching to `/server_info` fixed it immediately.

## Ref
Closes #44