### PR TITLE
Bump chart appVersion to v0.2.0 ahead of the v0.2.0 app release

### DIFF
--- a/charts/dagster-prometheus-exporter/Chart.yaml
+++ b/charts/dagster-prometheus-exporter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dagster-prometheus-exporter
 description: A Prometheus exporter for Dagster run metrics
 type: application
-version: 0.1.0
-appVersion: "v0.1.1"
+version: 0.1.1
+appVersion: "v0.2.0"
 home: https://github.com/HirofumiTsuda/dagster-prometheus-exporter
 sources:
   - https://github.com/HirofumiTsuda/dagster-prometheus-exporter

--- a/charts/dagster-prometheus-exporter/README.md
+++ b/charts/dagster-prometheus-exporter/README.md
@@ -8,7 +8,7 @@ The chart is published as an OCI artifact to GHCR:
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.0 \
+  --version 0.1.1 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 


### PR DESCRIPTION
## What

Chart version `0.1.0` → `0.1.1` (patch bump — only the `appVersion` pointer changes, no template/values schema changes) and `appVersion` `v0.1.1` → `v0.2.0`.

## Why

`v0.2.0` is a minor bump from the last app release (`v0.1.1`): five new metrics landed since then (`dagster_code_location_load_error`, `dagster_last_run_duration_seconds`, `dagster_active_run_duration_seconds`, `dagster_run_queue_concurrency_key_backlog`, `dagster_schedule_status`/`dagster_schedule_last_tick_status`, `dagster_sensor_status`/`dagster_sensor_last_tick_status`) plus `dagster_exporter_build_info` — all additive/backward-compatible.

This PR only updates `Chart.yaml`/the chart README's version reference. The actual `v0.2.0` and `chart-v0.1.1` tags get pushed after this merges, to trigger `docker-publish.yml`/`helm-publish.yml`.

## QA

- `helm lint --strict charts/dagster-prometheus-exporter` passes.
- `helm template` confirms the default image now resolves to `ghcr.io/hirofumitsuda/dagster-prometheus-exporter:v0.2.0`.

## Ref
N/A