### PR TITLE
Add Artifact Hub annotations and keywords to the Helm chart

### DIFF
--- a/charts/dagster-prometheus-exporter/Chart.yaml
+++ b/charts/dagster-prometheus-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dagster-prometheus-exporter
 description: A Prometheus exporter for Dagster run metrics
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2.0"
 home: https://github.com/HirofumiTsuda/dagster-prometheus-exporter
 sources:
@@ -10,3 +10,18 @@ sources:
 maintainers:
   - name: HirofumiTsuda
     url: https://github.com/HirofumiTsuda
+keywords:
+  - dagster
+  - prometheus
+  - monitoring
+  - observability
+  - grafana
+annotations:
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/license: MIT
+  artifacthub.io/links: |
+    - name: GitHub
+      url: https://github.com/HirofumiTsuda/dagster-prometheus-exporter
+    - name: Issues
+      url: https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues
+  artifacthub.io/prerelease: "false"

--- a/charts/dagster-prometheus-exporter/README.md
+++ b/charts/dagster-prometheus-exporter/README.md
@@ -8,7 +8,7 @@ The chart is published as an OCI artifact to GHCR:
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.1 \
+  --version 0.1.2 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 


### PR DESCRIPTION
## What

Adds Artifact Hub-recognized `annotations` (category, license, links, prerelease) and top-level `keywords` to the Helm chart's `Chart.yaml`. Bumps chart version to `0.1.2` since chart content changed.

## Why

Preparing to list the chart on [Artifact Hub](https://artifacthub.io/) (registering the `oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter` repository is a separate, manual step via their control panel — not part of this PR). These annotations make the listing richer (category, license badge, GitHub/Issues links) once registered. `artifacthub-repo.yml` (needed for the "Verified Publisher" badge) is deferred to a later PR.

## QA

- `helm lint charts/dagster-prometheus-exporter` — passes (only a pre-existing informational note about a missing icon)
- `helm template` with `DAGSTER_GRAPHQL_ENDPOINT` set — renders correctly, chart label reflects `0.1.2`

## Ref