### PR TITLE
Push artifacthub-repo.yml as OCI metadata for Verified Publisher status

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -48,3 +48,12 @@ jobs:
         run: |
           chart_package="$(ls dagster-prometheus-exporter-*.tgz)"
           helm push "$chart_package" "$OCI_REPO"
+
+      - uses: oras-project/setup-oras@v1
+
+      - name: Push Artifact Hub repository metadata
+        run: |
+          oras push \
+            "${REGISTRY}/hirofumitsuda/charts/dagster-prometheus-exporter:artifacthub.io" \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            "$CHART_PATH/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml"

--- a/charts/dagster-prometheus-exporter/.helmignore
+++ b/charts/dagster-prometheus-exporter/.helmignore
@@ -6,3 +6,5 @@
 *.tmp
 *.bak
 *.swp
+# Pushed separately as its own OCI artifact by helm-publish.yml, not chart content.
+artifacthub-repo.yml

--- a/charts/dagster-prometheus-exporter/artifacthub-repo.yml
+++ b/charts/dagster-prometheus-exporter/artifacthub-repo.yml
@@ -1,0 +1,9 @@
+# Verifies ownership of the Artifact Hub repository registered at
+# https://artifacthub.io/packages/helm/dagster-prometheus-exporter/dagster-prometheus-exporter
+# (repository URL: oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter).
+#
+# This file itself isn't bundled into the packaged chart; helm-publish.yml
+# pushes it as a separate OCI artifact tagged `artifacthub.io` alongside each
+# chart release, which is how Artifact Hub expects to find it for an
+# OCI-hosted repository. See https://artifacthub.io/docs/topics/repositories/#ownership-claim
+repositoryID: 79e3dc3e-9ae9-4404-8c12-6b044c2c3684


### PR DESCRIPTION
## What

Adds `charts/dagster-prometheus-exporter/artifacthub-repo.yml` with the `repositoryID` assigned when registering the chart on Artifact Hub, and a `helm-publish.yml` step that pushes it to GHCR as a separate `:artifacthub.io`-tagged OCI artifact after each chart publish. Excluded from the packaged chart tarball via `.helmignore` since it's repository metadata, not chart content.

## Why

Per Artifact Hub's [OCI repository ownership-claim mechanism](https://artifacthub.io/docs/topics/repositories/#ownership-claim), an OCI-hosted Helm repository proves ownership (and earns the "Verified Publisher" label) by pushing `artifacthub-repo.yml` containing the repository's assigned ID as a sibling OCI artifact tagged `artifacthub.io`, since there's no filesystem/HTTP index to place it next to like a traditional chart repo.

## QA

- `helm lint --strict charts/dagster-prometheus-exporter` — passes
- `helm package` locally — confirmed `artifacthub-repo.yml` is excluded from the resulting `.tgz`
- YAML validated (`.github/workflows/helm-publish.yml`, `artifacthub-repo.yml`)
- The actual `oras push` will run for real on the next `chart-v*.*.*` tag (or a manual `workflow_dispatch`) — not exercised in this PR's CI since it only runs on tag push

## Ref