### PR TITLE
Fix chart appVersion/published-tag mismatch (broken default image.tag)

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -24,6 +24,29 @@ jobs:
 
       - run: helm template charts/dagster-prometheus-exporter
 
+      - name: Verify the default image tag exists on GHCR
+        # Regression check for the appVersion/published-tag mismatch that
+        # slipped through undetected because the e2e test always overrides
+        # image.tag (see dev/kubernetes/exporter-e2e-values.yaml) and never
+        # exercises this default-value path. Renders with no overrides,
+        # same as a `helm install` with no --set image.tag, and confirms the
+        # resulting image:tag actually exists on GHCR (anonymous, no auth
+        # needed since the image is public).
+        run: |
+          image_ref="$(helm template charts/dagster-prometheus-exporter | grep -m1 'image:' | sed -E 's/.*image: "?([^"]+)"?/\1/')"
+          repo="${image_ref%%:*}"
+          tag="${image_ref##*:}"
+          registry_path="${repo#ghcr.io/}"
+          token="$(curl -sL "https://ghcr.io/token?scope=repository:${registry_path}:pull" | jq -r .token)"
+          status="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $token" \
+            -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json' \
+            "https://ghcr.io/v2/${registry_path}/manifests/${tag}")"
+          echo "GET manifest for $image_ref -> HTTP $status"
+          if [ "$status" != "200" ]; then
+            echo "::error::Default chart image '$image_ref' does not exist on GHCR (HTTP $status). Chart.yaml's appVersion likely doesn't match a real published Docker tag (check for a stray 'v' prefix)." >&2
+            exit 1
+          fi
+
       - name: Render with a representative set of overrides
         run: |
           helm template charts/dagster-prometheus-exporter \

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Or deploy to Kubernetes with the [Helm chart](charts/dagster-prometheus-exporter
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.2 \
+  --version 0.1.3 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 

--- a/charts/dagster-prometheus-exporter/Chart.yaml
+++ b/charts/dagster-prometheus-exporter/Chart.yaml
@@ -2,8 +2,12 @@ apiVersion: v2
 name: dagster-prometheus-exporter
 description: A Prometheus exporter for Dagster run metrics
 type: application
-version: 0.1.2
-appVersion: "v0.2.0"
+version: 0.1.3
+# Must exactly match a real tag on ghcr.io/hirofumitsuda/dagster-prometheus-exporter
+# (no "v" prefix — docker/metadata-action's {{version}} pattern in
+# docker-publish.yml strips it from the git tag when publishing), since
+# templates/deployment.yaml defaults image.tag to this value.
+appVersion: "0.2.0"
 home: https://github.com/HirofumiTsuda/dagster-prometheus-exporter
 sources:
   - https://github.com/HirofumiTsuda/dagster-prometheus-exporter

--- a/charts/dagster-prometheus-exporter/README.md
+++ b/charts/dagster-prometheus-exporter/README.md
@@ -8,7 +8,7 @@ The chart is published as an OCI artifact to GHCR:
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.2 \
+  --version 0.1.3 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 


### PR DESCRIPTION
## What

- `Chart.yaml`: `appVersion` changed from `"v0.2.0"` to `"0.2.0"` (no `v` prefix), plus a comment documenting why it must match the real published Docker tag exactly. Bumps chart version to `0.1.3`.
- `helm-lint.yml`: adds a step that renders the chart with **no overrides** and confirms the resulting default image reference actually exists on GHCR (anonymous manifest check).
- Bumps the sample `--version` in both READMEs to `0.1.3`.

## Why

`templates/deployment.yaml` defaults `image.tag` to `.Chart.AppVersion`. `Chart.yaml` had `appVersion: "v0.2.0"`, but `docker-publish.yml`'s `docker/metadata-action` strips the `v` prefix when publishing (actual GHCR tags: `0.1.0`, `0.1.1`, `0.2.0`, ...). So installing the chart without explicitly setting `image.tag` referenced a tag that doesn't exist — `ImagePullBackOff`.

This shipped in `chart-v0.1.0` through `chart-v0.1.2` unnoticed because `helm-e2e.yml`'s e2e test always overrides `image.tag` via `dev/kubernetes/exporter-e2e-values.yaml` (it points at a locally kind-loaded image), so CI never rendered the default-value path. It was caught by Artifact Hub's own image scanner after registering the chart there.

## QA

- `helm lint --strict charts/dagster-prometheus-exporter` — passes
- `helm template charts/dagster-prometheus-exporter` (no overrides) now renders `image: "ghcr.io/hirofumitsuda/dagster-prometheus-exporter:0.2.0"`, confirmed to resolve with an anonymous GHCR manifest request (`HTTP 200`)
- New `helm-lint.yml` step reproduces and validates the same check that would have caught this before merge

## Ref