### PR TITLE
Add a scheduled smoke test that installs the latest published chart

### DIFF
--- a/.github/workflows/helm-published-smoke.yml
+++ b/.github/workflows/helm-published-smoke.yml
@@ -1,0 +1,53 @@
+name: Published chart smoke test
+
+# Complements helm-e2e.yml, which always builds the exporter/Dagster images
+# fresh from the current checkout — useful for catching regressions in
+# main, but it bypasses the registry entirely, so it can't catch drift
+# between what's published and what the chart's defaults actually resolve
+# to. That gap is exactly how the appVersion/tag mismatch fixed in
+# chart-v0.1.3 shipped undetected (see #64): the chart's default image.tag
+# referenced a tag that didn't exist on GHCR.
+#
+# This installs the latest published chart from GHCR with no image
+# overrides — the same command a first-time user following the README
+# would run — into a kind cluster, and asserts the pod actually reaches
+# Ready. No real Dagster instance is needed for this: readinessProbe is
+# /healthz (doesn't depend on Dagster connectivity), so this only proves
+# "the published chart's defaults produce a container that starts and
+# passes its health check," not full functional correctness — that's what
+# helm-e2e.yml is for.
+#
+# Scheduled + on-demand, not pull_request/push, for the same reasons as
+# helm-e2e.yml: a kind cluster spin-up is heavy per-PR, and this is
+# inherently about the current *published* state, not whatever's in the PR
+# branch — a chart/docker change in a PR hasn't been published yet, so
+# testing it here wouldn't make sense until after merge and release anyway.
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: helm/kind-action@v1
+        with:
+          cluster_name: dagster-exporter-published-smoke
+
+      - uses: azure/setup-helm@v5
+
+      - name: Install the latest published chart (no image overrides)
+        run: |
+          helm install smoke oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
+            --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dummy:3000/graphql \
+            --wait --timeout=120s
+
+      - name: Dump pod state for debugging
+        if: failure()
+        run: |
+          kubectl get pods -o wide
+          POD_LABEL_SELECTOR="app.kubernetes.io/instance=smoke"
+          kubectl describe pod -l "$POD_LABEL_SELECTOR"
+          kubectl logs -l "$POD_LABEL_SELECTOR" --tail=200 || true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Release](https://img.shields.io/github/v/release/HirofumiTsuda/dagster-prometheus-exporter)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/releases/latest)
 [![CI](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/ci.yml)
 [![Helm e2e](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/helm-e2e.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/helm-e2e.yml)
+[![Published chart smoke test](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/helm-published-smoke.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/helm-published-smoke.yml)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/dagster-prometheus-exporter)](https://artifacthub.io/packages/helm/dagster-prometheus-exporter/dagster-prometheus-exporter)
 [![codecov](https://codecov.io/gh/HirofumiTsuda/dagster-prometheus-exporter/graph/badge.svg)](https://codecov.io/gh/HirofumiTsuda/dagster-prometheus-exporter)
 [![CodeQL](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml/badge.svg)](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/actions/workflows/codeql.yml)
@@ -313,6 +314,12 @@ curl http://localhost:9101/metrics
 
 kind delete cluster --name dagster-exporter-e2e
 ```
+
+### Verifying the published chart actually installs
+
+`.github/workflows/helm-published-smoke.yml` (status: see the badge at the top of this README) is a narrower, complementary check: it `helm install`s the *latest published* chart straight from GHCR with no `image.tag`/`image.repository` overrides — the same command a first-time user following this README's [Usage](#usage) section would run — and asserts the pod reaches `Ready`. Unlike `helm-e2e.yml` above, it never builds anything from the local checkout, so it's the only check that would have caught the chart's `appVersion`/published-tag mismatch that shipped in `chart-v0.1.0`–`0.1.2` (see [chart-v0.1.3](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/releases/tag/chart-v0.1.3)): the chart rendered without error and `helm install` reported success either way, since Helm doesn't validate that a container image reference actually resolves — only the pod itself failed to pull it. No real Dagster instance is involved, since `readinessProbe` is `/healthz` (doesn't depend on Dagster connectivity) — this only proves the published defaults produce a container that starts, not full functional correctness.
+
+Also scheduled + on-demand rather than per-PR, for the same reasons as `helm-e2e.yml` — plus a PR's chart/image changes aren't published yet, so there'd be nothing new for this check to test until after merge and release anyway.
 
 ### Running tests
 


### PR DESCRIPTION
## What

Adds `.github/workflows/helm-published-smoke.yml`: `helm install`s the *latest published* chart from GHCR with no `image.tag`/`image.repository` overrides — the same command a first-time user following the README's Usage section would run — into a kind cluster, and asserts the pod reaches `Ready`. Adds a badge and a README subsection documenting it, next to the existing "Testing the Helm chart against a real Dagster (kind)" section.

## Why

`helm-e2e.yml` always builds the exporter/Dagster images fresh from the current checkout and never touches the registry, so it can't catch drift between what's published and what the chart's defaults actually resolve to. That's exactly the gap that let the `appVersion`/tag mismatch fixed in `chart-v0.1.3` (#64) ship undetected in `chart-v0.1.0`–`0.1.2`: `helm install` reported success regardless, since Helm doesn't validate that a container image reference resolves — only the pod itself failed with `ImagePullBackOff`. This workflow is a permanent regression check for that class of bug going forward.

No real Dagster instance is needed here (`readinessProbe` is `/healthz`), so this only proves the published defaults produce a container that starts — `helm-e2e.yml` remains the check for full functional correctness against a real Dagster instance.

Scheduled + on-demand rather than per-PR, for the same reasons as `helm-e2e.yml` (heavy kind spin-up, more prone to transient flakiness) — plus a PR's own chart/image changes aren't published yet, so there'd be nothing new for this check to exercise until after merge and release.

## QA

- Ran the exact `helm install ... --wait --timeout=120s` command from the workflow locally against a throwaway kind cluster, using the real published `chart-v0.1.3`: succeeded, pod reached `1/1 Running` with no real Dagster instance running
- YAML validated

## Ref

Related to #64.