### PR TITLE
Reject GraphQL union error members instead of treating them as empty results

### DIFF
--- a/internal/collector/code_locations.go
+++ b/internal/collector/code_locations.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 
@@ -23,12 +22,11 @@ func CollectCodeLocationStatus(ctx context.Context, c *DagsterCollector) error {
 		return err
 	}
 
-	if resp.Data.WorkspaceOrError.Typename == "PythonError" {
-		err := fmt.Errorf("dagster reported a workspace load error: %s", resp.Data.WorkspaceOrError.Message)
-		log.Printf("failed to collect code location status from dagster: %v\n%s", err, strings.Join(resp.Data.WorkspaceOrError.Stack, "\n"))
-		return err
-	}
-
+	// A workspace-level PythonError is already rejected by getWorkspaceStatus
+	// (see unexpectedUnionMember), so reaching here means locationEntries is
+	// trustworthy. The per-entry check below is a different thing entirely:
+	// it's the metric itself, reporting which individual code locations
+	// failed to load while the workspace query as a whole succeeded.
 	loadErrors := make(map[string]bool, len(resp.Data.WorkspaceOrError.LocationEntries))
 	for _, entry := range resp.Data.WorkspaceOrError.LocationEntries {
 		failed := entry.LocationOrLoadError.Typename == "PythonError"

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"strings"
 )
 
 // closeBody closes an HTTP response body, discarding the error. By this
@@ -17,6 +19,40 @@ import (
 // keeps that intentional discard out of every call site.
 func closeBody(body io.Closer) {
 	_ = body.Close()
+}
+
+// unexpectedUnionMember reports that a GraphQL union resolved to something
+// other than the success type the caller can actually read.
+//
+// Dagster signals query-level failures through the union itself
+// (PythonError, InvalidPipelineRunsFilterError, ...) rather than through
+// GraphQL's top-level "errors" array. A failed query therefore decodes into
+// a perfectly well-formed response whose result list is simply empty, which
+// is indistinguishable from "there is nothing there" unless __typename is
+// checked. Treating that as success used to let one transient Dagster error
+// prune every accumulated series — known jobs, completed-run counters,
+// last-run status, schedules, sensors — while the collector still returned
+// nil and dagster_exporter_last_scrape_success kept reporting 1 (issue #69).
+//
+// Anything that isn't the expected success type is therefore an error,
+// including an absent __typename: every query in queries/ selects
+// __typename, so its absence means the response isn't the shape this code
+// was written against and its emptiness can't be trusted either.
+//
+// stack is logged rather than folded into the error: it's multi-line, only
+// useful for debugging, and the error itself is logged as a single line by
+// the calling collector.
+func unexpectedUnionMember(field, want, got, message string, stack []string) error {
+	if len(stack) > 0 {
+		log.Printf("dagster returned %s for %s:\n%s", got, field, strings.Join(stack, "\n"))
+	}
+	if got == "" {
+		got = "a response with no __typename"
+	}
+	if message == "" {
+		message = "(no message provided)"
+	}
+	return fmt.Errorf("%s returned %s instead of %s: %s", field, got, want, message)
 }
 
 type GraphQLRequest struct {
@@ -154,6 +190,10 @@ func getRuns(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoin
 		return nil, fmt.Errorf("graphql error: %s", graphQLResp.Errors[0].Message)
 	}
 
+	if runsOrError := graphQLResp.Data.RunsOrError; runsOrError.Typename != "Runs" {
+		return nil, unexpectedUnionMember("runsOrError", "Runs", runsOrError.Typename, runsOrError.Message, runsOrError.Stack)
+	}
+
 	return &graphQLResp, nil
 }
 
@@ -252,6 +292,10 @@ func getDefinitionsRoster(ctx context.Context, request *GraphQLRequest, dagsterG
 		return nil, fmt.Errorf("graphql error: %s", graphQLResp.Errors[0].Message)
 	}
 
+	if repositoriesOrError := graphQLResp.Data.RepositoriesOrError; repositoriesOrError.Typename != "RepositoryConnection" {
+		return nil, unexpectedUnionMember("repositoriesOrError", "RepositoryConnection", repositoriesOrError.Typename, repositoriesOrError.Message, repositoriesOrError.Stack)
+	}
+
 	return &graphQLResp, nil
 }
 
@@ -317,6 +361,10 @@ func getWorkspaceStatus(ctx context.Context, request *GraphQLRequest, dagsterGra
 
 	if len(graphQLResp.Errors) > 0 {
 		return nil, fmt.Errorf("graphql error: %s", graphQLResp.Errors[0].Message)
+	}
+
+	if workspaceOrError := graphQLResp.Data.WorkspaceOrError; workspaceOrError.Typename != "Workspace" {
+		return nil, unexpectedUnionMember("workspaceOrError", "Workspace", workspaceOrError.Typename, workspaceOrError.Message, workspaceOrError.Stack)
 	}
 
 	return &graphQLResp, nil

--- a/internal/collector/union_errors_test.go
+++ b/internal/collector/union_errors_test.go
@@ -1,0 +1,185 @@
+package collector
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pythonErrorBody is what Dagster returns when a query fails on the Python
+// side: HTTP 200, a well-formed body, no top-level "errors" array, and the
+// union resolved to PythonError instead of the expected result type. The
+// point of these tests is that this must not be mistaken for a successful
+// query that happened to find nothing (issue #69).
+func pythonErrorBody(field string) string {
+	return `{"data": {"` + field + `": {
+		"__typename": "PythonError",
+		"message": "dagster exploded",
+		"stack": ["Traceback (most recent call last):", "  raise Exception"]
+	}}}`
+}
+
+// scriptedServer is a GraphQL stub whose response body can be swapped
+// mid-test, so a collector can be brought to a known-good state first and
+// only then be shown a failure — which is the only way to observe whether
+// that earlier state survives the failure.
+type scriptedServer struct {
+	body atomic.Value
+	url  string
+}
+
+func newScriptedServer(t *testing.T, body string) *scriptedServer {
+	t.Helper()
+	s := &scriptedServer{}
+	s.body.Store(body)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(s.body.Load().(string)))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(ts.Close)
+	s.url = ts.URL
+	return s
+}
+
+func (s *scriptedServer) serve(body string) { s.body.Store(body) }
+
+func TestCollectDefinitionsRosterRejectsPythonErrorWithoutDiscardingState(t *testing.T) {
+	const goodRoster = `{"data": {"repositoriesOrError": {
+		"__typename": "RepositoryConnection",
+		"nodes": [
+			{
+				"name": "repo", "location": {"name": "loc_a"},
+				"jobs": [{"name": "job_a"}],
+				"schedules": [{"name": "sched_a", "cronSchedule": "* * * * *", "scheduleState": {"status": "RUNNING", "ticks": []}}],
+				"sensors": [{"name": "sensor_a", "sensorState": {"status": "RUNNING", "ticks": []}}]
+			}
+		]
+	}}}`
+
+	s := newScriptedServer(t, goodRoster)
+	c := NewDagsterCollector(t.Context(), s.url, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	require.NoError(t, CollectDefinitionsRoster(t.Context(), c))
+
+	jobKey := JobKey{JobName: "job_a", LocationName: "loc_a"}
+	require.Contains(t, c.knownJobs, jobKey)
+	seededSeries := testutil.CollectAndCount(c.completedRunsCounter)
+	require.Positive(t, seededSeries)
+
+	// Accumulated across scrapes rather than refetched, so pruning it is
+	// unrecoverable until the job next completes a run.
+	lastRun := lastRunEntry{status: "SUCCESS", endTime: 100, duration: 42}
+	c.lastRunStatus[jobKey] = lastRun
+
+	s.serve(pythonErrorBody("repositoriesOrError"))
+
+	err := CollectDefinitionsRoster(t.Context(), c)
+	require.Error(t, err, "a PythonError must not be reported as a successful but empty roster")
+	assert.Contains(t, err.Error(), "dagster exploded")
+
+	assert.Contains(t, c.knownJobs, jobKey,
+		"known jobs must survive a failed roster scrape")
+	assert.Equal(t, seededSeries, testutil.CollectAndCount(c.completedRunsCounter),
+		"dagster_completed_runs_total series must not be pruned by a failed roster scrape (pruning them looks like a counter reset to PromQL)")
+	assert.Equal(t, lastRun, c.lastRunStatus[jobKey],
+		"last-run state must not be pruned by a failed roster scrape")
+	assert.Len(t, c.scheduleStatus, 1,
+		"schedule status must not be replaced with an empty map by a failed roster scrape")
+	assert.Len(t, c.sensorStatus, 1,
+		"sensor status must not be replaced with an empty map by a failed roster scrape")
+}
+
+func TestRunCollectorsRejectRunsOrErrorFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		contains string
+	}{
+		{
+			name:     "python error",
+			body:     pythonErrorBody("runsOrError"),
+			contains: "dagster exploded",
+		},
+		{
+			// Means the exporter's own filter is wrong, which is worth
+			// surfacing loudly rather than reporting as "no runs".
+			name:     "invalid filter",
+			body:     `{"data": {"runsOrError": {"__typename": "InvalidPipelineRunsFilterError", "message": "bad filter"}}}`,
+			contains: "bad filter",
+		},
+		{
+			// Every query in queries/ selects __typename, so a response
+			// without one isn't the shape this code was written against —
+			// its empty result list can't be trusted either.
+			name:     "missing typename",
+			body:     `{"data": {"runsOrError": {"results": []}}}`,
+			contains: "no __typename",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newScriptedServer(t, tc.body)
+			c := NewDagsterCollector(t.Context(), s.url, time.Hour, time.Hour, 500, 5*time.Minute)
+
+			activeErr := CollectActiveRuns(t.Context(), c)
+			require.Error(t, activeErr, "CollectActiveRuns must not treat a failed runsOrError as zero active runs")
+			assert.Contains(t, activeErr.Error(), tc.contains)
+
+			completedErr := CollectCompletedRuns(t.Context(), c)
+			require.Error(t, completedErr, "CollectCompletedRuns must not treat a failed runsOrError as zero completed runs")
+			assert.Contains(t, completedErr.Error(), tc.contains)
+		})
+	}
+}
+
+func TestCollectActiveRunsRejectsPythonErrorWithoutDiscardingAggregates(t *testing.T) {
+	const goodRuns = `{"data": {"runsOrError": {"__typename": "Runs", "results": [
+		{
+			"runId": "r1", "jobName": "job_a", "status": "STARTED",
+			"creationTime": 100, "updateTime": 100,
+			"repositoryOrigin": {"repositoryName": "repo", "repositoryLocationName": "loc_a"}
+		}
+	]}}}`
+
+	s := newScriptedServer(t, goodRuns)
+	c := NewDagsterCollector(t.Context(), s.url, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	require.NoError(t, CollectActiveRuns(t.Context(), c))
+	require.Len(t, c.activeRunAggregates, 1)
+
+	s.serve(pythonErrorBody("runsOrError"))
+	require.Error(t, CollectActiveRuns(t.Context(), c))
+
+	assert.Len(t, c.activeRunAggregates, 1,
+		"active-run aggregates are replaced wholesale on success, so a failed scrape must leave the previous ones in place rather than blanking them")
+}
+
+func TestCollectCodeLocationStatusRejectsPythonErrorWithoutDiscardingState(t *testing.T) {
+	const goodWorkspace = `{"data": {"workspaceOrError": {
+		"__typename": "Workspace",
+		"locationEntries": [{"name": "loc_a", "locationOrLoadError": {"__typename": "RepositoryLocation"}}]
+	}}}`
+
+	s := newScriptedServer(t, goodWorkspace)
+	c := NewDagsterCollector(t.Context(), s.url, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	require.NoError(t, CollectCodeLocationStatus(t.Context(), c))
+	require.Len(t, c.codeLocationLoadError, 1)
+
+	s.serve(pythonErrorBody("workspaceOrError"))
+
+	err := CollectCodeLocationStatus(t.Context(), c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dagster exploded")
+	assert.Len(t, c.codeLocationLoadError, 1,
+		"code location state must not be replaced with an empty map by a failed scrape")
+}


### PR DESCRIPTION
## What

Check `__typename` on every GraphQL union the exporter reads, and turn anything that isn't the expected success type into a returned error.

| Field | Expected success type | Checked in |
|---|---|---|
| `runsOrError` | `Runs` | `getRuns` |
| `repositoriesOrError` | `RepositoryConnection` | `getDefinitionsRoster` |
| `workspaceOrError` | `Workspace` | `getWorkspaceStatus` |

A shared `unexpectedUnionMember` helper builds the error, logging `stack` rather than folding it into the message.

Two structural notes:

- The `workspaceOrError` check moves out of `CollectCodeLocationStatus` and into `getWorkspaceStatus`, so all three checks live at the same layer. The per-entry `locationOrLoadError` check stays where it is — that one is the `dagster_code_location_load_error` metric itself, not error handling, which the new comment there spells out.
- The `runsOrError` check has to sit in `getRuns`, not `fetchRunPages`. Seen one page at a time, a `PythonError` looks like an empty page and ends pagination cleanly.

The check is "must be the success type" rather than "must not be one of these known error types", so future union members — and responses missing `__typename` entirely — are caught as well. Every query in `queries/` selects `__typename`, so its absence means the response isn't the shape this code was written against, and its emptiness can't be trusted either.

## Why

Dagster signals query-level failures through the union itself (`PythonError`, `InvalidPipelineRunsFilterError`, ...) rather than through GraphQL's top-level `errors` array. A failed query therefore decodes into a well-formed 200 response whose result list is simply empty — indistinguishable from "there is nothing there" unless `__typename` is checked. The response structs already declared `Typename`/`Message`/`Stack` and the `.graphql` files already selected them, but only `workspaceOrError` was ever actually checked.

So a `PythonError` from `repositoriesOrError` looked like a successful scrape that found nothing:

- `buildKnownJobs` returned an empty set, so `pruneCompletedRunsCounter` deleted every `dagster_completed_runs_total` series — which reads as a counter reset to PromQL once the next successful scrape re-seeds them from 0.
- `pruneLastRunStatus` wiped the accumulated `dagster_last_run_info` / `dagster_last_run_duration_seconds` state. That state exists specifically to outlive the completed-runs lookback window, so it does not come back on its own.
- `scheduleStatus` / `scheduleTickStatus` / `sensorStatus` / `sensorTickStatus` were replaced wholesale with empty maps.

All of it silent: the collector returned `nil`, so `dagster_exporter_last_scrape_success` stayed `1` and `dagster_exporter_scrape_errors_total` never incremented. The self-health metrics added in #28 asserted everything was fine while every other metric family was being erased. `runsOrError` had the same gap.

## QA

**Unit tests** (`internal/collector/union_errors_test.go`, new). Verified these actually catch the regression by reverting the fix and re-running — all four fail without it:

```
--- FAIL: TestCollectDefinitionsRosterRejectsPythonErrorWithoutDiscardingState
        Error:    An error is expected but got nil.
        Messages: a PythonError must not be reported as a successful but empty roster
--- FAIL: TestRunCollectorsRejectRunsOrErrorFailures/python_error
--- FAIL: TestRunCollectorsRejectRunsOrErrorFailures/invalid_filter
--- FAIL: TestRunCollectorsRejectRunsOrErrorFailures/missing_typename
--- FAIL: TestCollectActiveRunsRejectsPythonErrorWithoutDiscardingAggregates
```

Beyond asserting an error is returned, they assert a failed scrape leaves prior state intact: `knownJobs`, the `completedRunsCounter` series count, `lastRunStatus`, `scheduleStatus`/`sensorStatus`, `activeRunAggregates`, and `codeLocationLoadError`.

**Against real Dagster 1.13.15** (`docker compose`), since guessing the success type names wrong would break every scrape:

```
runsOrError          -> "Runs"
repositoriesOrError  -> "RepositoryConnection"
workspaceOrError     -> "Workspace"
```

Ran the exporter against that instance: `/readyz` returned `{"status":"OK","version":"1.13.15"}`, all four collectors reported `dagster_exporter_last_scrape_success 1`, and all eight Dagster metric families populated. Re-ran with `dev/workspace.yaml` (which adds the deliberately broken code location) to confirm the untouched per-entry path in `code_locations.go` still works:

```
dagster_code_location_load_error{location="broken_location"} 1
dagster_code_location_load_error{location="dev-dagster-location"} 0
```

The `PythonError` path itself is covered by the unit tests rather than on real Dagster — provoking a genuine workspace-level `PythonError` would mean deliberately breaking the Dagster instance.

`go build` / `go vet` / `gofmt` / `go test -race` / `golangci-lint` all clean.

## Ref

Closes #69. Related: #71 collapses the four near-identical GraphQL executor functions into one, which will move these three checks into a single shared place.