### PR TITLE
Tidy go.mod and add a CI check that keeps it that way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,17 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # Keeps go.mod's direct/indirect split honest. Nothing else in CI
+      # reads it, so without this it drifts silently as dependencies come
+      # and go.
+      - name: Check go.mod and go.sum are tidy
+        run: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo "::error::go.mod/go.sum are not tidy. Run 'go mod tidy' and commit the result."
+            exit 1
+          fi
+
       - run: go build ./...
 
       - run: go vet ./...

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/jellydator/ttlcache/v3 v3.4.1
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -15,7 +16,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	golang.org/x/sync v0.21.0 // indirect


### PR DESCRIPTION
## What

Run `go mod tidy`, and add a step to `ci.yml`'s `test` job that fails if `go.mod`/`go.sum` are ever untidy again.

The tidy itself moves one line — `github.com/prometheus/client_model` from the indirect block into the direct one:

```diff
 require (
 	github.com/jellydator/ttlcache/v3 v3.4.1
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
 )
...
-	github.com/prometheus/client_model v0.6.2 // indirect
```

## Why

`client_model` is imported directly by seven test files:

```
internal/server/build_info_test.go
internal/server/scrape_test.go
internal/collector/active_runs_test.go
internal/collector/code_locations_test.go
internal/collector/completed_runs_test.go
internal/collector/definitions_roster_test.go
internal/collector/scrape_health_test.go
```

but was still recorded as indirect. Nothing breaks either way — the module resolves fine and `go build`/`go test` are happy — so this drifted unnoticed and would have kept drifting, because nothing in CI reads `go.mod` beyond `setup-go`'s version lookup.

Keeping the direct/indirect split honest is what tells a reader, and anyone auditing the dependency surface, which modules this project actually depends on versus which it merely inherits.

The check goes in the existing `test` job rather than a new one, so it reuses the `setup-go` step and the `changes` path filter (already triggered by `**.go`, `go.mod`, `go.sum`) — one step instead of a whole job. A bare `git diff --exit-code` failure isn't self-explanatory in a CI log, so the step emits a `::error::` annotation naming the fix.

## QA

Verified the guard in both directions by running its exact shell logic locally:

```
=== case 1: tidy tree — expect PASS
RESULT: pass (exit 0)

=== case 2: drifted tree — expect FAIL
::error::go.mod/go.sum are not tidy. Run 'go mod tidy' and commit the result.
RESULT: fail (exit 1)
```

Confirmed `go mod tidy` is now a no-op on this branch (byte-identical `go.mod`/`go.sum` before and after), and that the workflow YAML still parses with the new step in the expected position.

`go build` / `go vet` / `gofmt` / `go test -race` all clean.

## Ref

Closes #75. Related: #76 covers the other half of this — tool versions that live only in workflow files, or nowhere.