### PR TITLE
Validate configuration at startup, and stop fetchRunPages panicking on an empty page

### DIFF
--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -149,7 +149,13 @@ func fetchRunPages(ctx context.Context, statuses []string, updateAfter float64, 
 			return err
 		}
 
-		if len(results) < pageSize {
+		// An empty page always ends pagination, checked separately from the
+		// short-page test below rather than folded into it: with a pageSize
+		// of zero or less, "len(results) < pageSize" is false for an empty
+		// page, and the cursor line would then index results[-1] and panic.
+		// config.Load rejects such a pageSize, but this loop shouldn't
+		// depend on its caller to stay memory-safe.
+		if len(results) == 0 || len(results) < pageSize {
 			return nil
 		}
 		cursor = results[len(results)-1].RunId

--- a/internal/collector/graphql_test.go
+++ b/internal/collector/graphql_test.go
@@ -203,3 +203,38 @@ func TestFetchRunPagesPaginatesUntilAShortPage(t *testing.T) {
 	assert.Equal(t, []string{"", "run_2", "run_5"}, seenCursors,
 		"each page's cursor should be the runId of the previous page's last result")
 }
+
+// A pageSize of zero or less makes "len(results) < pageSize" false for an
+// empty page, which used to fall through to results[len(results)-1] and
+// panic with index out of range [-1] — inside one of scrapeDagster's
+// goroutines, so it took the whole process down rather than failing a
+// scrape. config.Load rejects such a pageSize now, but fetchRunPages
+// shouldn't depend on its caller to stay memory-safe.
+func TestFetchRunPagesStopsOnAnEmptyPageWhateverThePageSize(t *testing.T) {
+	for _, pageSize := range []int{0, -1} {
+		t.Run(fmt.Sprintf("pageSize=%d", pageSize), func(t *testing.T) {
+			calls := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				require.Less(t, calls, 5, "fetchRunPages should have stopped after the first empty page")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write([]byte(`{"data": {"runsOrError": {"__typename": "Runs", "results": []}}}`))
+				assert.NoError(t, err)
+			}))
+			defer ts.Close()
+
+			pages := 0
+			require.NotPanics(t, func() {
+				err := fetchRunPages(t.Context(), []string{"SUCCESS"}, 0, ts.URL, pageSize, func(page []Run) error {
+					pages++
+					return nil
+				})
+				assert.NoError(t, err)
+			})
+
+			assert.Equal(t, 1, calls, "an empty first page should end pagination immediately")
+			assert.Equal(t, 1, pages)
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"log"
+	"math"
 	"os"
 	"strconv"
 	"time"
@@ -18,8 +20,15 @@ type Config struct {
 	RunsUpdatedAfterSafetyMargin time.Duration
 }
 
-// getEnvInt は環境変数 key を int として読み込む。未設定なら def を返す。
-func getEnvInt(key string, def int) (int, error) {
+// getEnvInt reads env var key as an int, returning def when it's unset, and
+// rejects anything outside [minVal, maxVal].
+//
+// The range check is what keeps a bad value from turning into a confusing
+// failure much later: RUNS_PAGE_SIZE=0 slips past fetchRunPages' end-of-
+// pagination test and panics, and a PORT outside the valid range only shows
+// up as a ListenAndServe failure that never names the env var responsible.
+// Failing here means the error says which setting is wrong.
+func getEnvInt(key string, def, minVal, maxVal int) (int, error) {
 	val := os.Getenv(key)
 	if val == "" {
 		return def, nil
@@ -28,11 +37,21 @@ func getEnvInt(key string, def int) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid %s value: %w", key, err)
 	}
+	if n < minVal || n > maxVal {
+		return 0, fmt.Errorf("invalid %s value: %d is outside the allowed range [%d, %d]", key, n, minVal, maxVal)
+	}
 	return n, nil
 }
 
-// getEnvDuration は環境変数 key を unit 単位の int として読み込み time.Duration に変換する。
-// 未設定なら def をそのまま返す(def は unit と異なる単位で組み立てられていてもよい)。
+// getEnvDuration reads env var key as an int count of unit and converts it
+// to a time.Duration, returning def unchanged when the var is unset (def may
+// be expressed in a different unit than unit).
+//
+// Zero and negative values are rejected, because every setting read through
+// here breaks something downstream at those values:
+// DAGSTER_SCRAPING_INTERVAL_SECONDS=0 panics time.NewTicker, and a negative
+// LOOKBACK_WINDOW_MINUTES puts updatedAfter in the future so the initial
+// backfill silently matches nothing.
 func getEnvDuration(key string, unit time.Duration, def time.Duration) (time.Duration, error) {
 	val := os.Getenv(key)
 	if val == "" {
@@ -42,7 +61,11 @@ func getEnvDuration(key string, unit time.Duration, def time.Duration) (time.Dur
 	if err != nil {
 		return 0, fmt.Errorf("invalid %s value: %w", key, err)
 	}
-	return time.Duration(n) * unit, nil
+	d := time.Duration(n) * unit
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid %s value: %d (must be positive)", key, n)
+	}
+	return d, nil
 }
 
 // processedRuns entries are touched (their TTL refreshed) on every scrape
@@ -54,9 +77,10 @@ func getEnvDuration(key string, unit time.Duration, def time.Duration) (time.Dur
 // failures before risking a double count.
 const cacheTTLScrapingIntervalMultiplier = 20
 
-// Load は環境変数などから設定を読み込んで返す
+// Load reads the exporter's configuration from environment variables,
+// applying defaults for anything unset and rejecting values that can't work.
 func Load() (*Config, error) {
-	port, err := getEnvInt("PORT", 9101)
+	port, err := getEnvInt("PORT", 9101, 1, 65535)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +114,9 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 
-	runsPageSize, err := getEnvInt("RUNS_PAGE_SIZE", 500)
+	// The upper bound is MaxInt32 because GraphQL's Int is 32-bit: a larger
+	// value can't be represented as the query's limit variable anyway.
+	runsPageSize, err := getEnvInt("RUNS_PAGE_SIZE", 500, 1, math.MaxInt32)
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +124,16 @@ func Load() (*Config, error) {
 	dagsterScrapingTimeout, err := getEnvDuration("DAGSTER_SCRAPING_TIMEOUT_SECONDS", time.Second, 10*time.Second)
 	if err != nil {
 		return nil, err
+	}
+
+	// Scrapes run serially inside startScrape's loop, so a timeout longer
+	// than the interval lets one slow scrape push the next tick back and
+	// stretch the effective interval. That isn't invalid — waiting longer on
+	// a temporarily slow Dagster is a reasonable thing to want — so this
+	// warns rather than errors, just so it doesn't happen unnoticed.
+	if dagsterScrapingTimeout > dagsterScrapingInterval {
+		log.Printf("warning: DAGSTER_SCRAPING_TIMEOUT_SECONDS (%v) is longer than DAGSTER_SCRAPING_INTERVAL_SECONDS (%v); a slow scrape will stretch the effective interval",
+			dagsterScrapingTimeout, dagsterScrapingInterval)
 	}
 
 	return &Config{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// configEnvVars is every environment variable Load reads. Tests blank them
+// all out first so a variable that happens to be set in the developer's own
+// shell can't change the result — an empty value is treated as unset by
+// getEnvInt/getEnvDuration, so this is equivalent to a clean environment.
+var configEnvVars = []string{
+	"PORT",
+	"DAGSTER_GRAPHQL_ENDPOINT",
+	"DAGSTER_SCRAPING_INTERVAL_SECONDS",
+	"DAGSTER_SCRAPING_TIMEOUT_SECONDS",
+	"RUNS_UPDATED_AFTER_SAFETY_MARGIN_MINUTES",
+	"CACHE_TTL_MINUTES",
+	"LOOKBACK_WINDOW_MINUTES",
+	"RUNS_PAGE_SIZE",
+}
+
+func setEnv(t *testing.T, env map[string]string) {
+	t.Helper()
+	for _, key := range configEnvVars {
+		t.Setenv(key, "")
+	}
+	for key, value := range env {
+		t.Setenv(key, value)
+	}
+}
+
+func TestLoadDefaults(t *testing.T) {
+	setEnv(t, nil)
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, 9101, cfg.Port)
+	assert.Equal(t, "http://127.0.0.1:3000/graphql", cfg.DagsterGraphQLEndpoint)
+	assert.Equal(t, 15*time.Second, cfg.DagsterScrapingInterval)
+	assert.Equal(t, 10*time.Second, cfg.DagsterScrapingTimeout)
+	assert.Equal(t, 5*time.Minute, cfg.RunsUpdatedAfterSafetyMargin)
+	assert.Equal(t, 500, cfg.RunsPageSize)
+
+	// Both of these are derived from the scraping interval rather than being
+	// fixed values, which is easy to break by accident — see the comments on
+	// cacheTTLScrapingIntervalMultiplier and LOOKBACK_WINDOW_MINUTES.
+	assert.Equal(t, cacheTTLScrapingIntervalMultiplier*15*time.Second, cfg.CacheTTL)
+	assert.Equal(t, 15*time.Second, cfg.LookbackWindow)
+}
+
+func TestLoadDerivedDefaultsFollowTheScrapingInterval(t *testing.T) {
+	setEnv(t, map[string]string{"DAGSTER_SCRAPING_INTERVAL_SECONDS": "30"})
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, 30*time.Second, cfg.DagsterScrapingInterval)
+	assert.Equal(t, 30*time.Second, cfg.LookbackWindow, "lookback window should default to the scraping interval")
+	assert.Equal(t, 10*time.Minute, cfg.CacheTTL, "cache TTL should default to 20x the scraping interval")
+}
+
+func TestLoadExplicitValuesOverrideDerivedDefaults(t *testing.T) {
+	setEnv(t, map[string]string{
+		"PORT":                                     "8080",
+		"DAGSTER_GRAPHQL_ENDPOINT":                 "http://dagster.example:3000/graphql",
+		"DAGSTER_SCRAPING_INTERVAL_SECONDS":        "30",
+		"DAGSTER_SCRAPING_TIMEOUT_SECONDS":         "20",
+		"RUNS_UPDATED_AFTER_SAFETY_MARGIN_MINUTES": "2",
+		"CACHE_TTL_MINUTES":                        "60",
+		"LOOKBACK_WINDOW_MINUTES":                  "120",
+		"RUNS_PAGE_SIZE":                           "250",
+	})
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, 8080, cfg.Port)
+	assert.Equal(t, "http://dagster.example:3000/graphql", cfg.DagsterGraphQLEndpoint)
+	assert.Equal(t, 30*time.Second, cfg.DagsterScrapingInterval)
+	assert.Equal(t, 20*time.Second, cfg.DagsterScrapingTimeout)
+	assert.Equal(t, 2*time.Minute, cfg.RunsUpdatedAfterSafetyMargin)
+	assert.Equal(t, 60*time.Minute, cfg.CacheTTL)
+	assert.Equal(t, 120*time.Minute, cfg.LookbackWindow)
+	assert.Equal(t, 250, cfg.RunsPageSize)
+}
+
+func TestLoadRejectsUnusableValues(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+	}{
+		{"port zero", map[string]string{"PORT": "0"}},
+		{"port above the valid range", map[string]string{"PORT": "65536"}},
+		{"port negative", map[string]string{"PORT": "-1"}},
+		{"port not a number", map[string]string{"PORT": "not-a-number"}},
+
+		// Zero used to slip past fetchRunPages' end-of-pagination check and
+		// panic on results[-1].
+		{"page size zero", map[string]string{"RUNS_PAGE_SIZE": "0"}},
+		{"page size negative", map[string]string{"RUNS_PAGE_SIZE": "-1"}},
+
+		// Zero panics time.NewTicker in startScrape.
+		{"scraping interval zero", map[string]string{"DAGSTER_SCRAPING_INTERVAL_SECONDS": "0"}},
+		{"scraping interval negative", map[string]string{"DAGSTER_SCRAPING_INTERVAL_SECONDS": "-15"}},
+
+		{"scraping timeout zero", map[string]string{"DAGSTER_SCRAPING_TIMEOUT_SECONDS": "0"}},
+
+		// Negative puts updatedAfter in the future, so the initial backfill
+		// silently matches nothing.
+		{"lookback window negative", map[string]string{"LOOKBACK_WINDOW_MINUTES": "-5"}},
+		{"lookback window zero", map[string]string{"LOOKBACK_WINDOW_MINUTES": "0"}},
+
+		{"cache TTL zero", map[string]string{"CACHE_TTL_MINUTES": "0"}},
+		{"safety margin zero", map[string]string{"RUNS_UPDATED_AFTER_SAFETY_MARGIN_MINUTES": "0"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setEnv(t, tc.env)
+
+			cfg, err := Load()
+
+			require.Error(t, err)
+			assert.Nil(t, cfg)
+			for key := range tc.env {
+				assert.Contains(t, err.Error(), key,
+					"the error should name the environment variable at fault, so the operator knows what to fix")
+			}
+		})
+	}
+}
+
+func TestLoadWarnsWhenTimeoutExceedsInterval(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	setEnv(t, map[string]string{
+		"DAGSTER_SCRAPING_INTERVAL_SECONDS": "10",
+		"DAGSTER_SCRAPING_TIMEOUT_SECONDS":  "30",
+	})
+
+	_, err := Load()
+	require.NoError(t, err, "a timeout longer than the interval is unusual, not invalid")
+	assert.Contains(t, buf.String(), "DAGSTER_SCRAPING_TIMEOUT_SECONDS")
+
+	buf.Reset()
+	setEnv(t, map[string]string{
+		"DAGSTER_SCRAPING_INTERVAL_SECONDS": "30",
+		"DAGSTER_SCRAPING_TIMEOUT_SECONDS":  "10",
+	})
+
+	_, err = Load()
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "the usual timeout < interval case should be silent")
+}

--- a/internal/server/scrape.go
+++ b/internal/server/scrape.go
@@ -50,7 +50,7 @@ func startScrape(ctx context.Context, c *collector.DagsterCollector, interval ti
 	for {
 		select {
 		case <-ctx.Done():
-			// アプリ終了シグナルを受け取ったらループを安全に抜ける
+			// Leave the loop cleanly once a shutdown signal arrives.
 			log.Println("Stopping background scraper...")
 			return
 


### PR DESCRIPTION
## What

- Guard `fetchRunPages` so an empty page always ends pagination, whatever `pageSize` is.
- Add range validation to `config.Load` via `getEnvInt`/`getEnvDuration`, so an unusable value fails at startup with an error naming the environment variable.
- Warn (without erroring) when `DAGSTER_SCRAPING_TIMEOUT_SECONDS` exceeds `DAGSTER_SCRAPING_INTERVAL_SECONDS`.
- Add the first tests for `internal/config`.
- Translate the last Japanese comments in the Go sources (`internal/config/config.go`, `internal/server/scrape.go:53`) to English.

| Setting | Accepted |
|---|---|
| `PORT` | 1–65535 |
| `RUNS_PAGE_SIZE` | 1–MaxInt32 (GraphQL's `Int` is 32-bit) |
| all duration settings | positive |

## Why

**The panic.** `fetchRunPages`' termination check assumed `pageSize >= 1`:

```go
if len(results) < pageSize {
    return nil
}
cursor = results[len(results)-1].RunId
```

With `pageSize <= 0`, an empty page fails `0 < 0`, falls through, and indexes `results[-1]`. That runs inside one of `scrapeDagster`'s goroutines, so it is an unrecovered panic that takes the whole process down rather than failing a single scrape. `RUNS_PAGE_SIZE=0` — one typo in the Helm chart's `env` map — was enough to trigger it.

**The validation.** `getEnvInt`/`getEnvDuration` accepted anything `strconv.Atoi` could parse, so several settings reached code that cannot handle them: `RUNS_PAGE_SIZE=0` as above, `DAGSTER_SCRAPING_INTERVAL_SECONDS=0` panicking `time.NewTicker` in `startScrape`, a negative `LOOKBACK_WINDOW_MINUTES` putting `updatedAfter` in the future so the initial backfill silently matches nothing, and a `PORT` outside the valid range surfacing only as a `ListenAndServe` failure that never says which variable was wrong.

The paging guard and the config check overlap deliberately: `config.Load` now rejects a bad `pageSize`, but `fetchRunPages` shouldn't depend on its caller to stay memory-safe.

**The timeout warning.** Scrapes run serially inside `startScrape`'s loop, so a timeout longer than the interval lets one slow scrape push the next tick back and stretch the effective interval. That is unusual rather than invalid — waiting longer on a temporarily slow Dagster is a reasonable thing to want — so it warns instead of failing.

## QA

Verified both fixes catch their regression by reverting each one and re-running.

Paging guard reverted:

```
--- FAIL: TestFetchRunPagesStopsOnAnEmptyPageWhateverThePageSize/pageSize=0
        Error: func (assert.PanicTestFunc) should not panic
        Panic value: runtime error: index out of range [-1]
```

Validation reverted — 12 of the 13 rejection subtests fail:

```
--- FAIL: TestLoadRejectsUnusableValues/port_zero
--- FAIL: TestLoadRejectsUnusableValues/port_above_the_valid_range
--- FAIL: TestLoadRejectsUnusableValues/port_negative
--- FAIL: TestLoadRejectsUnusableValues/page_size_zero
--- FAIL: TestLoadRejectsUnusableValues/page_size_negative
--- FAIL: TestLoadRejectsUnusableValues/scraping_interval_zero
--- FAIL: TestLoadRejectsUnusableValues/scraping_interval_negative
--- FAIL: TestLoadRejectsUnusableValues/scraping_timeout_zero
--- FAIL: TestLoadRejectsUnusableValues/lookback_window_negative
--- FAIL: TestLoadRejectsUnusableValues/lookback_window_zero
--- FAIL: TestLoadRejectsUnusableValues/cache_TTL_zero
--- FAIL: TestLoadRejectsUnusableValues/safety_margin_zero
```

The thirteenth (`port_not_a_number`) still passes, since `strconv.Atoi` already rejected it — the expected result.

The config tests also lock in the two defaults derived from the scraping interval (`CACHE_TTL_MINUTES` at 20x, `LOOKBACK_WINDOW_MINUTES` at 1x), which are easy to break by accident, and blank every config variable first so a value set in the developer's own shell can't affect the result.

`go build` / `go vet` / `gofmt` / `go test -race` / `golangci-lint` all clean, and no non-ASCII comments remain in any `.go` file.

## Ref

Closes #70. Also completes the comment-language item from #72.