### PR TITLE
Pin golangci-lint and helm in .tool-versions so local and CI match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
               - "**.go"
               - go.mod
               - go.sum
+              # golangci-lint's version lives here now, so a bump has to
+              # re-run the lint job.
+              - .tool-versions
               - .github/workflows/ci.yml
             python:
               - "**.py"
@@ -77,10 +80,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # version-file reads .tool-versions, the same file mise reads locally,
+      # so there's one place to bump golangci-lint rather than a CI pin that
+      # local installs drift away from. It requires the default binary
+      # install-mode (goinstall doesn't support it), which is what
+      # golangci-lint recommends anyway — official release binaries instead
+      # of a build against whatever Go version happens to be present.
       - uses: golangci/golangci-lint-action@v9
         with:
-          install-mode: goinstall
-          version: v2.12.2
+          version-file: .tool-versions
 
   python-lint:
     needs: changes

--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -29,7 +29,11 @@ jobs:
         with:
           cluster_name: dagster-exporter-e2e
 
-      - uses: azure/setup-helm@v5
+      # Installs helm at the version in .tool-versions, so CI and local
+      # development run the same one. azure/setup-helm defaults to "latest",
+      # which is not reproducible and drifted a major version away from the
+      # helm used for local chart testing.
+      - uses: jdx/mise-action@v4
 
       - name: Build exporter and Dagster dev images
         run: |

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -5,11 +5,15 @@ on:
     branches: [main]
     paths:
       - "charts/**"
+      # helm's own version lives here now.
+      - ".tool-versions"
       - ".github/workflows/helm-lint.yml"
   pull_request:
     branches: [main]
     paths:
       - "charts/**"
+      # helm's own version lives here now.
+      - ".tool-versions"
       - ".github/workflows/helm-lint.yml"
 
 jobs:
@@ -18,7 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: azure/setup-helm@v5
+      # Installs helm at the version in .tool-versions, so CI and local
+      # development run the same one. azure/setup-helm defaults to "latest",
+      # which is not reproducible and drifted a major version away from the
+      # helm used for local chart testing.
+      - uses: jdx/mise-action@v4
 
       - run: helm lint --strict charts/dagster-prometheus-exporter
 

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -21,7 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: azure/setup-helm@v5
+      # Installs helm at the version in .tool-versions, so CI and local
+      # development run the same one. azure/setup-helm defaults to "latest",
+      # which is not reproducible and drifted a major version away from the
+      # helm used for local chart testing.
+      - uses: jdx/mise-action@v4
 
       - name: Verify tag matches Chart.yaml version
         if: github.event_name == 'push'

--- a/.github/workflows/helm-published-smoke.yml
+++ b/.github/workflows/helm-published-smoke.yml
@@ -36,7 +36,11 @@ jobs:
         with:
           cluster_name: dagster-exporter-published-smoke
 
-      - uses: azure/setup-helm@v5
+      # Installs helm at the version in .tool-versions, so CI and local
+      # development run the same one. azure/setup-helm defaults to "latest",
+      # which is not reproducible and drifted a major version away from the
+      # helm used for local chart testing.
+      - uses: jdx/mise-action@v4
 
       - name: Install the latest published chart (no image overrides)
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,19 @@
+# Versions for the tools a developer runs by hand, so a local run matches
+# what CI does. Both previously differed by a major version between the two:
+# golangci-lint was pinned only inside ci.yml (CI v2, local v1), and helm was
+# pinned nowhere at all (azure/setup-helm defaults to "latest", which has been
+# Helm 4 since v4.1.0, while local development was on Helm 3).
+#
+# This file, rather than mise.toml, because golangci-lint-action reads
+# .tool-versions directly via its version-file input. That keeps one file as
+# the source of truth with no glue code: mise reads it locally, and each
+# workflow reads it in CI.
+#
+# Go is deliberately absent: go.mod is already its single source of truth,
+# and actions/setup-go reads it there while also providing module caching.
+#
+# kind, oras and uv are absent too. Their setup actions bake a fixed default
+# into each major tag (kind v0.31.0, oras 1.3.1), so Dependabot moves them
+# deliberately rather than by drift.
+golangci-lint 2.12.2
+helm 4.2.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,32 @@ Open a [GitHub issue](https://github.com/HirofumiTsuda/dagster-prometheus-export
 
 CI (`.github/workflows/ci.yml`) runs the same checks on every push and pull request, plus CodeQL static analysis.
 
+## Setting up your toolchain
+
+Go comes from `go.mod` — any Go 1.21+ will fetch the toolchain it names automatically.
+
+The other tools are pinned in [`.tool-versions`](.tool-versions) so that a local run matches CI. With [mise](https://mise.jdx.dev/) installed:
+
+```sh
+mise install
+```
+
+Installing them another way works too, as long as the versions match `.tool-versions`. They differ enough to matter: golangci-lint v1 and v2 enable different linters by default, and Helm 3 and 4 are separate major versions, so running a different one means checking something CI doesn't.
+
 ## Running checks locally
 
 ```sh
 go build ./...
 go vet ./...
 golangci-lint run ./...
-go test ./...
+go test -race ./...
+```
+
+For chart changes:
+
+```sh
+helm lint --strict charts/dagster-prometheus-exporter
+helm template charts/dagster-prometheus-exporter
 ```
 
 ## Local development stack


### PR DESCRIPTION
## What

Add `.tool-versions` pinning `golangci-lint` and `helm`, and have every consumer read it:

| Consumer | How it reads `.tool-versions` |
|---|---|
| local development | `mise install` |
| `ci.yml` lint job | `golangci-lint-action`'s `version-file` input |
| the four helm workflows | `jdx/mise-action@v4`, replacing `azure/setup-helm@v5` |

Also adds `.tool-versions` to `ci.yml`'s `go` path filter and `helm-lint.yml`'s triggers so a bump re-runs the jobs it affects, and documents toolchain setup in `CONTRIBUTING.md`, which previously said nothing about it.

`version-file` requires the default `binary` install-mode, so `install-mode: goinstall` is dropped. That's the mode golangci-lint recommends anyway — official release binaries rather than a build against whatever Go happens to be present.

## Why

Both tools were being run at a **different major version locally than in CI**:

```
golangci-lint    CI: v2.12.2     local: v1.64.8
helm             CI: 4.2.4       local: 3.21.3
```

- **golangci-lint** was pinned only inside `ci.yml`, with nothing saying what to install locally. v1 and v2 enable different default linters (v2 folded `gosimple` into `staticcheck`), and there's no `.golangci.yml`, so each ran its own built-in defaults. During #69 that made a clean local run weak evidence — it had to be treated as inconclusive until CI confirmed it.
- **helm** was pinned nowhere: `azure/setup-helm@v5` defaults to `latest`, which has been Helm **4.x** since v4.1.0 (2026-01-21), i.e. from before this repo existed. Local chart testing was on Helm 3.

Helm 4 clearly works — `helm-published-smoke.yml` has been green on every scheduled run — so this is not a breakage, it's that local chart testing (the manual kind runs behind #33 and #64) was exercising a different major version than CI.

The two versions do not produce identical output. Rendering the chart with each:

```diff
   data:
     PORT: "9101"
+
  ---
```

Cosmetic — trailing blank lines before the document separators, no semantic difference — but it confirms the divergence is real rather than theoretical.

### What is deliberately not in `.tool-versions`

- **Go** — `go.mod` is already its single source of truth, and `actions/setup-go` reads it there while also providing module caching. Adding it here would create the duplication this change exists to remove.
- **kind, oras, uv** — checking each action's `action.yml`, these are not floating: `helm/kind-action@v1` defaults to kind `v0.31.0` and `oras-project/setup-oras@v2` to oras `1.3.1`, both baked into the major tag, so Dependabot already moves them deliberately. `ruff` is pinned at its call site (`uvx ruff@0.16.2`) regardless of uv's version. (The original issue claimed these floated; that was wrong, and the issue has been corrected.)

## QA

- `mise install` resolves both tools from `.tool-versions`, comments included:

  ```
  golangci-lint  2.12.2  .../.tool-versions  2.12.2
  helm           4.2.4   .../.tool-versions  4.2.4
  ```

  Go still resolves from the global config rather than this file, as intended.

- Ran the CI-version linter locally for the first time — `golangci-lint 2.12.2` reports `0 issues`, confirming the v1/v2 gap was hiding nothing.
- `helm lint --strict` and `helm template` both pass against the pinned Helm 4.2.4, and were diffed against Helm 3.21.3 (see above).
- All seven workflow files still parse as YAML.
- `go build` / `go vet` / `gofmt` / `go test -race` clean.

The one thing that can only be confirmed by CI is `golangci-lint-action`'s `version-file` parsing of this file — if it can't read it, the lint job fails loudly rather than silently running the wrong version.

## Ref

Closes #76.