### PR TITLE
Collapse the four GraphQL executor functions into one doGraphQL

### DIFF
--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -53,55 +53,49 @@ func (e *graphQLErrors) err() error {
 	return nil
 }
 
-// graphQLResponse constrains doGraphQL's type parameter to response types
-// that embed graphQLErrors. The two-parameter form (T for the value, PT for
-// its pointer) is what lets doGraphQL both allocate a T and call the
-// pointer-receiver err() on it.
-type graphQLResponse[T any] interface {
-	*T
+// graphQLResponse is implemented by every response type, via the
+// graphQLErrors it embeds. Callers pass a pointer to their own response
+// value, so the pointer-receiver err() is in the method set.
+type graphQLResponse interface {
 	err() error
 }
 
-// doGraphQL posts request to endpoint and decodes the reply into T.
+// doGraphQL posts request to endpoint and decodes the reply into out, in the
+// same shape as json.Unmarshal: the caller owns the destination value and
+// passes a pointer to it.
 //
 // Every query goes through here so that transport-level policy — the
 // context-controlled timeout, the status-code check, the top-level "errors"
 // check — is defined once. It used to be copied into a separate 36-line
 // function per query, and that duplication is exactly how the union checks
 // in issue #69 came to exist in one copy but not the others.
-func doGraphQL[T any, PT graphQLResponse[T]](ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (PT, error) {
+func doGraphQL(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string, out graphQLResponse) error {
 	jsonBytes, err := json.Marshal(request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal graphql request: %w", err)
+		return fmt.Errorf("failed to marshal graphql request: %w", err)
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, dagsterGraphQLEndpoint, bytes.NewBuffer(jsonBytes))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create http request: %w", err)
+		return fmt.Errorf("failed to create http request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := graphQLClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute http request: %w", err)
+		return fmt.Errorf("failed to execute http request: %w", err)
 	}
 	defer closeBody(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	var decoded T
-	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	out := PT(&decoded)
-	if err := out.err(); err != nil {
-		return nil, err
-	}
-
-	return out, nil
+	return out.err()
 }
 
 // unexpectedUnionMember reports that a GraphQL union resolved to something
@@ -244,8 +238,8 @@ func fetchRunPages(ctx context.Context, statuses []string, updateAfter float64, 
 }
 
 func getRuns(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLRunsResponse, error) {
-	resp, err := doGraphQL[GraphQLRunsResponse](ctx, request, dagsterGraphQLEndpoint)
-	if err != nil {
+	var resp GraphQLRunsResponse
+	if err := doGraphQL(ctx, request, dagsterGraphQLEndpoint, &resp); err != nil {
 		return nil, err
 	}
 
@@ -253,7 +247,7 @@ func getRuns(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoin
 		return nil, unexpectedUnionMember("runsOrError", "Runs", runsOrError.Typename, runsOrError.Message, runsOrError.Stack)
 	}
 
-	return resp, nil
+	return &resp, nil
 }
 
 // GraphQLDefinitionsRosterResponse is the shape of repositoriesOrError used
@@ -316,8 +310,8 @@ func getDefinitionsRosterRequest() *GraphQLRequest {
 }
 
 func getDefinitionsRoster(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLDefinitionsRosterResponse, error) {
-	resp, err := doGraphQL[GraphQLDefinitionsRosterResponse](ctx, request, dagsterGraphQLEndpoint)
-	if err != nil {
+	var resp GraphQLDefinitionsRosterResponse
+	if err := doGraphQL(ctx, request, dagsterGraphQLEndpoint, &resp); err != nil {
 		return nil, err
 	}
 
@@ -325,7 +319,7 @@ func getDefinitionsRoster(ctx context.Context, request *GraphQLRequest, dagsterG
 		return nil, unexpectedUnionMember("repositoriesOrError", "RepositoryConnection", repositoriesOrError.Typename, repositoriesOrError.Message, repositoriesOrError.Stack)
 	}
 
-	return resp, nil
+	return &resp, nil
 }
 
 type GraphQLWorkspaceStatusResponse struct {
@@ -357,8 +351,8 @@ func getWorkspaceStatusRequest() *GraphQLRequest {
 }
 
 func getWorkspaceStatus(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLWorkspaceStatusResponse, error) {
-	resp, err := doGraphQL[GraphQLWorkspaceStatusResponse](ctx, request, dagsterGraphQLEndpoint)
-	if err != nil {
+	var resp GraphQLWorkspaceStatusResponse
+	if err := doGraphQL(ctx, request, dagsterGraphQLEndpoint, &resp); err != nil {
 		return nil, err
 	}
 
@@ -366,7 +360,7 @@ func getWorkspaceStatus(ctx context.Context, request *GraphQLRequest, dagsterGra
 		return nil, unexpectedUnionMember("workspaceOrError", "Workspace", workspaceOrError.Typename, workspaceOrError.Message, workspaceOrError.Stack)
 	}
 
-	return resp, nil
+	return &resp, nil
 }
 
 //go:embed queries/get_version.graphql
@@ -388,8 +382,8 @@ func GetVersionRequest() *GraphQLRequest {
 }
 
 func GetVersion(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLVersionResponse, error) {
-	resp, err := doGraphQL[GraphQLVersionResponse](ctx, request, dagsterGraphQLEndpoint)
-	if err != nil {
+	var resp GraphQLVersionResponse
+	if err := doGraphQL(ctx, request, dagsterGraphQLEndpoint, &resp); err != nil {
 		return nil, err
 	}
 
@@ -400,5 +394,5 @@ func GetVersion(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndp
 		return nil, fmt.Errorf("graphql version response missing version")
 	}
 
-	return resp, nil
+	return &resp, nil
 }

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -21,6 +21,89 @@ func closeBody(body io.Closer) {
 	_ = body.Close()
 }
 
+// graphQLClient is shared by every query. A zero-value http.Client already
+// reuses http.DefaultTransport's connection pool, so this isn't about
+// pooling — it's about having one place to set client-level policy, and one
+// seam to swap in tests.
+//
+// Timeout is intentionally left unset: callers control how long a request
+// may run through the context they pass (see http.NewRequestWithContext in
+// doGraphQL). Setting it here would silently cap the per-scrape deadline
+// that DAGSTER_SCRAPING_TIMEOUT_SECONDS is supposed to own.
+var graphQLClient = &http.Client{}
+
+// graphQLErrors is embedded in every response type to carry GraphQL's
+// top-level "errors" array. Embedding keeps the field promoted to the top
+// level of the JSON document, so the wire format is unchanged.
+//
+// Note this is a different failure channel from the unions handled by
+// unexpectedUnionMember: Dagster reports most query-level problems through
+// the union, and only protocol-level problems (a malformed query, an
+// unknown field) show up here.
+type graphQLErrors struct {
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func (e *graphQLErrors) err() error {
+	if len(e.Errors) > 0 {
+		return fmt.Errorf("graphql error: %s", e.Errors[0].Message)
+	}
+	return nil
+}
+
+// graphQLResponse constrains doGraphQL's type parameter to response types
+// that embed graphQLErrors. The two-parameter form (T for the value, PT for
+// its pointer) is what lets doGraphQL both allocate a T and call the
+// pointer-receiver err() on it.
+type graphQLResponse[T any] interface {
+	*T
+	err() error
+}
+
+// doGraphQL posts request to endpoint and decodes the reply into T.
+//
+// Every query goes through here so that transport-level policy — the
+// context-controlled timeout, the status-code check, the top-level "errors"
+// check — is defined once. It used to be copied into a separate 36-line
+// function per query, and that duplication is exactly how the union checks
+// in issue #69 came to exist in one copy but not the others.
+func doGraphQL[T any, PT graphQLResponse[T]](ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (PT, error) {
+	jsonBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal graphql request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, dagsterGraphQLEndpoint, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create http request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := graphQLClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute http request: %w", err)
+	}
+	defer closeBody(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var decoded T
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	out := PT(&decoded)
+	if err := out.err(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 // unexpectedUnionMember reports that a GraphQL union resolved to something
 // other than the success type the caller can actually read.
 //
@@ -96,9 +179,7 @@ type GraphQLRunsResponse struct {
 			Stack    []string `json:"stack"`
 		} `json:"runsOrError"`
 	} `json:"data"`
-	Errors []struct {
-		Message string `json:"message"`
-	} `json:"errors"`
+	graphQLErrors
 }
 
 //go:embed queries/get_runs.graphql
@@ -163,44 +244,16 @@ func fetchRunPages(ctx context.Context, statuses []string, updateAfter float64, 
 }
 
 func getRuns(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLRunsResponse, error) {
-	jsonBytes, err := json.Marshal(request)
+	resp, err := doGraphQL[GraphQLRunsResponse](ctx, request, dagsterGraphQLEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal graphql request: %w", err)
+		return nil, err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, dagsterGraphQLEndpoint, bytes.NewBuffer(jsonBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create http request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	// Timeout is intentionally not set here: the caller controls how long a
-	// request may run via ctx (see http.NewRequestWithContext above).
-	client := &http.Client{}
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute http request: %w", err)
-	}
-	defer closeBody(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	var graphQLResp GraphQLRunsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&graphQLResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	if len(graphQLResp.Errors) > 0 {
-		return nil, fmt.Errorf("graphql error: %s", graphQLResp.Errors[0].Message)
-	}
-
-	if runsOrError := graphQLResp.Data.RunsOrError; runsOrError.Typename != "Runs" {
+	if runsOrError := resp.Data.RunsOrError; runsOrError.Typename != "Runs" {
 		return nil, unexpectedUnionMember("runsOrError", "Runs", runsOrError.Typename, runsOrError.Message, runsOrError.Stack)
 	}
 
-	return &graphQLResp, nil
+	return resp, nil
 }
 
 // GraphQLDefinitionsRosterResponse is the shape of repositoriesOrError used
@@ -250,9 +303,7 @@ type GraphQLDefinitionsRosterResponse struct {
 			Stack   []string `json:"stack"`
 		} `json:"repositoriesOrError"`
 	} `json:"data"`
-	Errors []struct {
-		Message string `json:"message"`
-	} `json:"errors"`
+	graphQLErrors
 }
 
 //go:embed queries/get_definitions_roster.graphql
@@ -265,44 +316,16 @@ func getDefinitionsRosterRequest() *GraphQLRequest {
 }
 
 func getDefinitionsRoster(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLDefinitionsRosterResponse, error) {
-	jsonBytes, err := json.Marshal(request)
+	resp, err := doGraphQL[GraphQLDefinitionsRosterResponse](ctx, request, dagsterGraphQLEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal graphql request: %w", err)
+		return nil, err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, dagsterGraphQLEndpoint, bytes.NewBuffer(jsonBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create http request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	// Timeout is intentionally not set here: the caller controls how long a
-	// request may run via ctx (see http.NewRequestWithContext above).
-	client := &http.Client{}
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute http request: %w", err)
-	}
-	defer closeBody(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	var graphQLResp GraphQLDefinitionsRosterResponse
-	if err := json.NewDecoder(resp.Body).Decode(&graphQLResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	if len(graphQLResp.Errors) > 0 {
-		return nil, fmt.Errorf("graphql error: %s", graphQLResp.Errors[0].Message)
-	}
-
-	if repositoriesOrError := graphQLResp.Data.RepositoriesOrError; repositoriesOrError.Typename != "RepositoryConnection" {
+	if repositoriesOrError := resp.Data.RepositoriesOrError; repositoriesOrError.Typename != "RepositoryConnection" {
 		return nil, unexpectedUnionMember("repositoriesOrError", "RepositoryConnection", repositoriesOrError.Typename, repositoriesOrError.Message, repositoriesOrError.Stack)
 	}
 
-	return &graphQLResp, nil
+	return resp, nil
 }
 
 type GraphQLWorkspaceStatusResponse struct {
@@ -321,9 +344,7 @@ type GraphQLWorkspaceStatusResponse struct {
 			Stack   []string `json:"stack"`
 		} `json:"workspaceOrError"`
 	} `json:"data"`
-	Errors []struct {
-		Message string `json:"message"`
-	} `json:"errors"`
+	graphQLErrors
 }
 
 //go:embed queries/get_workspace_status.graphql
@@ -336,44 +357,16 @@ func getWorkspaceStatusRequest() *GraphQLRequest {
 }
 
 func getWorkspaceStatus(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLWorkspaceStatusResponse, error) {
-	jsonBytes, err := json.Marshal(request)
+	resp, err := doGraphQL[GraphQLWorkspaceStatusResponse](ctx, request, dagsterGraphQLEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal graphql request: %w", err)
+		return nil, err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, dagsterGraphQLEndpoint, bytes.NewBuffer(jsonBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create http request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	// Timeout is intentionally not set here: the caller controls how long a
-	// request may run via ctx (see http.NewRequestWithContext above).
-	client := &http.Client{}
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute http request: %w", err)
-	}
-	defer closeBody(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	var graphQLResp GraphQLWorkspaceStatusResponse
-	if err := json.NewDecoder(resp.Body).Decode(&graphQLResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	if len(graphQLResp.Errors) > 0 {
-		return nil, fmt.Errorf("graphql error: %s", graphQLResp.Errors[0].Message)
-	}
-
-	if workspaceOrError := graphQLResp.Data.WorkspaceOrError; workspaceOrError.Typename != "Workspace" {
+	if workspaceOrError := resp.Data.WorkspaceOrError; workspaceOrError.Typename != "Workspace" {
 		return nil, unexpectedUnionMember("workspaceOrError", "Workspace", workspaceOrError.Typename, workspaceOrError.Message, workspaceOrError.Stack)
 	}
 
-	return &graphQLResp, nil
+	return resp, nil
 }
 
 //go:embed queries/get_version.graphql
@@ -383,6 +376,7 @@ type GraphQLVersionResponse struct {
 	Data struct {
 		Version string `json:"version"`
 	} `json:"data"`
+	graphQLErrors
 }
 
 func GetVersionRequest() *GraphQLRequest {
@@ -394,38 +388,17 @@ func GetVersionRequest() *GraphQLRequest {
 }
 
 func GetVersion(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLVersionResponse, error) {
-	jsonBytes, err := json.Marshal(request)
+	resp, err := doGraphQL[GraphQLVersionResponse](ctx, request, dagsterGraphQLEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal graphql request: %w", err)
+		return nil, err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, dagsterGraphQLEndpoint, bytes.NewBuffer(jsonBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create http request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	// Timeout is intentionally not set here: the caller controls how long a
-	// request may run via ctx (see http.NewRequestWithContext above).
-	client := &http.Client{}
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute http request: %w", err)
-	}
-	defer closeBody(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	var graphQLResp GraphQLVersionResponse
-	if err := json.NewDecoder(resp.Body).Decode(&graphQLResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	if len(graphQLResp.Data.Version) == 0 {
+	// version isn't a union, so there's no __typename to check. An empty
+	// value is the only signal that the reply didn't carry what /readyz
+	// needs.
+	if len(resp.Data.Version) == 0 {
 		return nil, fmt.Errorf("graphql version response missing version")
 	}
 
-	return &graphQLResp, nil
+	return resp, nil
 }

--- a/internal/collector/graphql_test.go
+++ b/internal/collector/graphql_test.go
@@ -238,3 +238,49 @@ func TestFetchRunPagesStopsOnAnEmptyPageWhateverThePageSize(t *testing.T) {
 		})
 	}
 }
+
+// The top-level "errors" array is carried by the embedded graphQLErrors
+// struct, so it reaches Go through promoted fields rather than a field
+// declared on each response type. Embedding is supposed to leave the wire
+// format untouched — this checks that it actually does, for each response
+// type, since nothing else in the suite exercises this channel.
+func TestGraphQLTopLevelErrorsAreReported(t *testing.T) {
+	const body = `{"data": {}, "errors": [{"message": "Cannot query field \"nope\""}]}`
+
+	queries := map[string]func(ctx context.Context, endpoint string) error{
+		"runsOrError": func(ctx context.Context, endpoint string) error {
+			_, err := getRuns(ctx, getRunsRequest([]string{"SUCCESS"}, 0, "", 500), endpoint)
+			return err
+		},
+		"repositoriesOrError": func(ctx context.Context, endpoint string) error {
+			_, err := getDefinitionsRoster(ctx, getDefinitionsRosterRequest(), endpoint)
+			return err
+		},
+		"workspaceOrError": func(ctx context.Context, endpoint string) error {
+			_, err := getWorkspaceStatus(ctx, getWorkspaceStatusRequest(), endpoint)
+			return err
+		},
+		"version": func(ctx context.Context, endpoint string) error {
+			_, err := GetVersion(ctx, GetVersionRequest(), endpoint)
+			return err
+		},
+	}
+
+	for name, query := range queries {
+		t.Run(name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write([]byte(body))
+				assert.NoError(t, err)
+			}))
+			defer ts.Close()
+
+			err := query(t.Context(), ts.URL)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Cannot query field",
+				"the GraphQL error message should survive decoding through the embedded struct")
+		})
+	}
+}


### PR DESCRIPTION
## What

Route all four GraphQL queries through one executor instead of four near-identical copies:

```go
func doGraphQL(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string, out graphQLResponse) error
```

The caller owns the response value and passes a pointer to it, the same shape as `json.Unmarshal`. Each query becomes a thin wrapper holding only what is specific to it — its union check:

```go
func getRuns(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLRunsResponse, error) {
	var resp GraphQLRunsResponse
	if err := doGraphQL(ctx, request, dagsterGraphQLEndpoint, &resp); err != nil {
		return nil, err
	}

	if runsOrError := resp.Data.RunsOrError; runsOrError.Typename != "Runs" {
		return nil, unexpectedUnionMember("runsOrError", "Runs", runsOrError.Typename, runsOrError.Message, runsOrError.Stack)
	}

	return &resp, nil
}
```

Also in this change:

- The top-level `errors` array moves to an embedded `graphQLErrors` struct with an `err()` method, so the check lives with the executor.
- One shared `http.Client` replaces the four per-call ones.
- `GraphQLVersionResponse` gains the `Errors` field the other three already had.

## Why

`getRuns`, `getDefinitionsRoster`, `getWorkspaceStatus` and `GetVersion` each held their own 36-line copy of the same seven steps — marshal, build the request, set `Content-Type`, construct a client, check the status code, decode, check `errors` — differing only in the response type they decoded into. The comment explaining why `Timeout` is deliberately unset appeared verbatim four times.

That duplication is not a hypothetical maintenance cost; it is how #69 happened. The union check was written once, in the copy handling `workspaceOrError`, and never reached the other three. With one executor, the next cross-cutting change cannot land in three places out of four.

### On the shape of the executor

The first draft of this PR made `doGraphQL` generic:

```go
func doGraphQL[T any, PT graphQLResponse[T]](ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (PT, error)
```

Two type parameters were needed because the function allocated the response value itself: with only `T` it could not call the pointer-receiver `err()` (`Resp does not satisfy hasErr (method err has pointer receiver)`), and making `T` the pointer type left `var decoded T` as a nil pointer with no way to allocate the pointee. The `*T` term tied the two together.

That entire problem was self-inflicted by the "allocate and return" signature. Letting the caller own the value means what arrives is *already* a pointer, so `err()` is in its method set and no type parameter is needed at all. It is also the shape every Go reader already knows from `json.Unmarshal(b, &out)`, `Decoder.Decode(&out)` and `Rows.Scan(&x)`.

For the record, line counts across the three shapes — the refactor is not a line-count win in any of them, and was never meant to be:

| | total | code only |
|---|---|---|
| four duplicated executors (before) | 431 | 308 |
| generic executor | 404 | 266 |
| **destination passed in (this PR)** | **398** | **260** |

Note `out` is `graphQLResponse`, not `*graphQLResponse`: it is an interface, and the pointer lives *inside* the interface value. `*graphQLResponse` would be a pointer to an interface, which `*GraphQLRunsResponse` does not satisfy.

## QA

- `go build` / `go vet` / `gofmt` / `go test -race` / `golangci-lint` (2.12.2, from `.tool-versions`) all clean.
- The existing collector tests are the regression net for the transport path, since every collector test now goes through `doGraphQL`.
- Added `TestGraphQLTopLevelErrorsAreReported`, covering all four response types. Embedding is supposed to leave the wire format untouched, but nothing in the suite exercised the top-level `errors` channel, so that assumption was previously unverified:

  ```
  --- PASS: TestGraphQLTopLevelErrorsAreReported/runsOrError
  --- PASS: TestGraphQLTopLevelErrorsAreReported/repositoriesOrError
  --- PASS: TestGraphQLTopLevelErrorsAreReported/workspaceOrError
  --- PASS: TestGraphQLTopLevelErrorsAreReported/version
  ```

  The `version` case is new behavior rather than a regression check: `GraphQLVersionResponse` had no `Errors` field before, so a GraphQL-level error surfaced only indirectly as `missing version`. It now reports the message Dagster actually sent.

Behavior is otherwise unchanged.

## Ref

Closes #71.