### PR TITLE
Collector housekeeping, and a lint rule so the shadowing doesn't come back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,10 @@ jobs:
               - "**.go"
               - go.mod
               - go.sum
-              # golangci-lint's version lives here now, so a bump has to
-              # re-run the lint job.
+              # golangci-lint's version and its enabled linters live in
+              # these two, so a change to either has to re-run the lint job.
               - .tool-versions
+              - .golangci.yml
               - .github/workflows/ci.yml
             python:
               - "**.py"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+# Without this file, golangci-lint runs whichever linters its own version
+# happens to enable by default — which is how a local v1 install and a CI v2
+# install ended up checking different things (see .tool-versions). Stating the
+# set explicitly makes it a property of the repository rather than of whoever
+# ran the tool.
+version: "2"
+
+linters:
+  # The standard set (errcheck, govet, ineffassign, staticcheck, unused) is
+  # what CI has effectively been running all along; it stays the baseline.
+  default: standard
+
+  enable:
+    - gocritic
+
+  settings:
+    gocritic:
+      enabled-checks:
+        # Not on by default, because naming a variable after a package it
+        # shadows is a matter of taste. This repository's taste is that it
+        # isn't worth it: the resulting compile error when someone later
+        # needs the package again reads "config.Config is not a type", which
+        # says nothing about the shadowing that caused it.
+        - importShadow

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/HirofumiTsuda/dagster-prometheus-exporter.svg)](https://pkg.go.dev/github.com/HirofumiTsuda/dagster-prometheus-exporter)
 [![License: MIT](https://img.shields.io/github/license/HirofumiTsuda/dagster-prometheus-exporter)](LICENSE)
 
-A Prometheus exporter for [Dagster](https://dagster.io/) run metrics. It polls Dagster's GraphQL API on an interval and exposes run counts, statuses, and code-location information as Prometheus metrics.
+A Prometheus exporter for [Dagster](https://dagster.io/). It polls Dagster's GraphQL API on an interval and exposes run counts, statuses and durations, schedule and sensor state, run-queue backlog, and code-location load errors as Prometheus metrics.
 
 ![Dagster Run Monitoring dashboard in Grafana](docs/images/grafana-dashboard.png)
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	config, err := config.Load()
+	cfg, err := config.Load()
 
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
@@ -20,7 +20,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	server.RunServer(ctx, config)
+	server.RunServer(ctx, cfg)
 
 	log.Println("Application completely stopped.")
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -4,6 +4,8 @@ Design rationale, edge cases, and blind spots for each metric. For the short ver
 
 The per-job metrics are labeled with `job_name` and `location` (the Dagster code location the job belongs to), so that jobs with the same name in different code locations don't collide. `dagster_code_location_load_error` is location-scoped rather than job-scoped, since it reports on a code location as a whole.
 
+A run records its code location as a launch-time snapshot (`repositoryOrigin`), and that field can be absent — for runs launched outside a code location, or old enough to predate it. Those runs are reported as `location="__unknown__"`. The name is deliberately not something a real code location would be called: the placeholder has to stay distinguishable from a location that genuinely exists, both so the two aren't summed into one series and because the exporter prunes series for locations Dagster no longer reports, which a collision would defeat. (Before v0.3.0 this placeholder was `unknown`, which a real code location could have been named.)
+
 ## `dagster_active_runs` (Gauge)
 
 Labels: `job_name`, `location`, `status`

--- a/internal/collector/active_runs.go
+++ b/internal/collector/active_runs.go
@@ -39,7 +39,10 @@ type activeRunAggregate struct {
 // current status" for every active status, without needing to special-case
 // STARTED with a separate startTime field.
 func elapsedSince(run Run, now time.Time) float64 {
-	return now.Sub(time.Unix(int64(run.UpdateTime), 0)).Seconds()
+	// updateTime is a float64 of seconds, so converting via time.Unix would
+	// discard the fractional part. Subtracting in float64 keeps it — this is
+	// a duration metric, and there's no reason to round it to whole seconds.
+	return float64(now.UnixNano())/1e9 - run.UpdateTime
 }
 
 // CollectActiveRuns fetches every QUEUED/STARTING/STARTED run and folds
@@ -56,13 +59,9 @@ func CollectActiveRuns(ctx context.Context, c *DagsterCollector) error {
 
 	err := fetchRunPages(ctx, activeStatuses, 0, c.dagsterGraphQLEndpoint, c.runsPageSize, func(page []Run) error {
 		for _, run := range page {
-			location := unknownLocationName
-			if run.RepositoryOrigin != nil {
-				location = run.RepositoryOrigin.RepositoryLocationName
-			}
 			key := ActiveRunKey{
 				JobName:      run.JobName,
-				LocationName: location,
+				LocationName: run.location(),
 				Status:       run.Status,
 			}
 

--- a/internal/collector/active_runs.go
+++ b/internal/collector/active_runs.go
@@ -38,11 +38,15 @@ type activeRunAggregate struct {
 // Dagster's source. So updateTime is exactly "when this run entered its
 // current status" for every active status, without needing to special-case
 // STARTED with a separate startTime field.
+//
+// int64(run.UpdateTime) drops the sub-second part of the timestamp, and that
+// is fine on purpose: this value is computed once per scrape and then served
+// unchanged until the next one, so by the time Prometheus reads it, it is
+// already up to a full scrape interval (15s by default) out of date. A
+// sub-second correction would be lost inside that. The consumers are
+// "queued longer than 10 minutes" style alerts, not stopwatch readings.
 func elapsedSince(run Run, now time.Time) float64 {
-	// updateTime is a float64 of seconds, so converting via time.Unix would
-	// discard the fractional part. Subtracting in float64 keeps it — this is
-	// a duration metric, and there's no reason to round it to whole seconds.
-	return float64(now.UnixNano())/1e9 - run.UpdateTime
+	return now.Sub(time.Unix(int64(run.UpdateTime), 0)).Seconds()
 }
 
 // CollectActiveRuns fetches every QUEUED/STARTING/STARTED run and folds

--- a/internal/collector/active_runs_test.go
+++ b/internal/collector/active_runs_test.go
@@ -201,16 +201,6 @@ func TestCollectActiveRunsAlsoTracksConcurrencyKeyBacklog(t *testing.T) {
 		"a previously-seen key should be zero-filled, not dropped, once its backlog clears")
 }
 
-func TestElapsedSinceKeepsSubSecondPrecision(t *testing.T) {
-	// updateTime is a float64 of seconds. Converting it through
-	// time.Unix(int64(...), 0) used to drop the fraction, rounding every
-	// dagster_active_run_duration_seconds value down to a whole second.
-	now := time.Unix(1000, 0)
-	run := Run{UpdateTime: 997.25}
-
-	assert.InDelta(t, 2.75, elapsedSince(run, now), 1e-6)
-}
-
 func TestRunLocationFallsBackWhenOriginIsAbsent(t *testing.T) {
 	withOrigin := Run{RepositoryOrigin: &RunRepositoryOrigin{RepositoryLocationName: "loc_a"}}
 	assert.Equal(t, "loc_a", withOrigin.location())

--- a/internal/collector/active_runs_test.go
+++ b/internal/collector/active_runs_test.go
@@ -200,3 +200,21 @@ func TestCollectActiveRunsAlsoTracksConcurrencyKeyBacklog(t *testing.T) {
 	assert.Equal(t, 0, c.concurrencyKeyBacklog["heavy_limit"],
 		"a previously-seen key should be zero-filled, not dropped, once its backlog clears")
 }
+
+func TestElapsedSinceKeepsSubSecondPrecision(t *testing.T) {
+	// updateTime is a float64 of seconds. Converting it through
+	// time.Unix(int64(...), 0) used to drop the fraction, rounding every
+	// dagster_active_run_duration_seconds value down to a whole second.
+	now := time.Unix(1000, 0)
+	run := Run{UpdateTime: 997.25}
+
+	assert.InDelta(t, 2.75, elapsedSince(run, now), 1e-6)
+}
+
+func TestRunLocationFallsBackWhenOriginIsAbsent(t *testing.T) {
+	withOrigin := Run{RepositoryOrigin: &RunRepositoryOrigin{RepositoryLocationName: "loc_a"}}
+	assert.Equal(t, "loc_a", withOrigin.location())
+
+	assert.Equal(t, unknownLocationName, Run{}.location(),
+		"a run with no repositoryOrigin should land in the placeholder location rather than an empty label")
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -9,7 +9,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const unknownLocationName = "unknown"
+// unknownLocationName is the location label for runs whose repositoryOrigin
+// is absent (launched outside a code location, or old enough to predate the
+// field). The surrounding underscores keep it from colliding with a real
+// code location name: a collision would sum "we don't know where this ran"
+// and "it ran in the location called unknown" into one series, and would
+// also defeat the pruning in pruneLastRunStatus/pruneCompletedRunsCounter,
+// which relies on placeholder keys never matching a live location.
+const unknownLocationName = "__unknown__"
 
 type DagsterCollector struct {
 	dagsterGraphQLEndpoint string
@@ -43,8 +50,7 @@ type DagsterCollector struct {
 	trackedCompletedRunKeys map[JobKey]struct{}
 	lastSeenUpdateTime      float64
 	runsPageSize            int
-	scrapeDuration          map[string]float64
-	lastScrapeSuccess       map[string]bool
+	scrapeResults           map[string]scrapeResult
 	codeLocationLoadError   map[string]bool
 	// runsUpdatedAfterSafetyMargin is subtracted from the last-seen
 	// updateTime watermark before it's used as the next scrape's
@@ -169,8 +175,7 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 		trackedCompletedRunKeys:      make(map[JobKey]struct{}),
 		runsPageSize:                 runsPageSize,
 		runsUpdatedAfterSafetyMargin: runsUpdatedAfterSafetyMargin,
-		scrapeDuration:               make(map[string]float64),
-		lastScrapeSuccess:            make(map[string]bool),
+		scrapeResults:                make(map[string]scrapeResult),
 	}
 }
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -9,15 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// unknownLocationName is the location label for runs whose repositoryOrigin
-// is absent (launched outside a code location, or old enough to predate the
-// field). The surrounding underscores keep it from colliding with a real
-// code location name: a collision would sum "we don't know where this ran"
-// and "it ran in the location called unknown" into one series, and would
-// also defeat the pruning in pruneLastRunStatus/pruneCompletedRunsCounter,
-// which relies on placeholder keys never matching a live location.
-const unknownLocationName = "__unknown__"
-
 type DagsterCollector struct {
 	dagsterGraphQLEndpoint string
 

--- a/internal/collector/completed_runs.go
+++ b/internal/collector/completed_runs.go
@@ -39,11 +39,7 @@ func CollectCompletedRuns(ctx context.Context, c *DagsterCollector) error {
 				maxUpdateTimeSeen = result.UpdateTime
 			}
 
-			location := unknownLocationName
-			if result.RepositoryOrigin != nil {
-				location = result.RepositoryOrigin.RepositoryLocationName
-			}
-
+			location := result.location()
 			key := JobKey{JobName: result.JobName, LocationName: location}
 			if current, ok := c.lastRunStatus[key]; !ok || result.EndTime > current.endTime {
 				c.lastRunStatus[key] = lastRunEntry{

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -153,10 +153,17 @@ type RunTag struct {
 	Value string `json:"value"`
 }
 
+// unknownLocationName is the location label for runs whose repositoryOrigin
+// is absent (launched outside a code location, or old enough to predate the
+// field). The surrounding underscores keep it from colliding with a real
+// code location name: a collision would sum "we don't know where this ran"
+// and "it ran in the location called unknown" into one series, and would
+// also defeat the pruning in pruneLastRunStatus/pruneCompletedRunsCounter,
+// which relies on placeholder keys never matching a live location.
+const unknownLocationName = "__unknown__"
+
 // location returns the code location a run was launched from, falling back
-// to unknownLocationName when repositoryOrigin is absent. Runs old enough to
-// predate the field, or launched outside a code location, have no origin
-// recorded.
+// to unknownLocationName when repositoryOrigin is absent.
 func (r Run) location() string {
 	if r.RepositoryOrigin == nil {
 		return unknownLocationName

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -153,6 +153,17 @@ type RunTag struct {
 	Value string `json:"value"`
 }
 
+// location returns the code location a run was launched from, falling back
+// to unknownLocationName when repositoryOrigin is absent. Runs old enough to
+// predate the field, or launched outside a code location, have no origin
+// recorded.
+func (r Run) location() string {
+	if r.RepositoryOrigin == nil {
+		return unknownLocationName
+	}
+	return r.RepositoryOrigin.RepositoryLocationName
+}
+
 type Run struct {
 	RunId            string               `json:"runId"`
 	JobName          string               `json:"jobName"`

--- a/internal/collector/scrape_health.go
+++ b/internal/collector/scrape_health.go
@@ -6,6 +6,16 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// scrapeResult is one collector's most recent scrape outcome. Duration and
+// success are always written together by RecordScrapeResult and always read
+// together by reflectScrapeHealth, so keeping them in one map rather than
+// two parallel ones removes the possibility of the two disagreeing about
+// which collectors exist.
+type scrapeResult struct {
+	duration float64
+	success  bool
+}
+
 // RecordScrapeResult records the outcome of one collector's most recent
 // scrape, so it can be reported via dagster_exporter_scrape_duration_seconds,
 // dagster_exporter_last_scrape_success, and dagster_exporter_scrape_errors_total.
@@ -13,8 +23,10 @@ func (c *DagsterCollector) RecordScrapeResult(collectorName string, duration tim
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	c.scrapeDuration[collectorName] = duration.Seconds()
-	c.lastScrapeSuccess[collectorName] = err == nil
+	c.scrapeResults[collectorName] = scrapeResult{
+		duration: duration.Seconds(),
+		success:  err == nil,
+	}
 
 	if err != nil {
 		c.scrapeErrorsCounter.WithLabelValues(collectorName).Inc()
@@ -25,24 +37,22 @@ func reflectScrapeHealth(c *DagsterCollector, ch chan<- prometheus.Metric) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	for name, duration := range c.scrapeDuration {
+	for name, result := range c.scrapeResults {
 		ch <- prometheus.MustNewConstMetric(
 			c.scrapeDurationDesc,
 			prometheus.GaugeValue,
-			duration,
+			result.duration,
 			name,
 		)
-	}
 
-	for name, success := range c.lastScrapeSuccess {
-		value := 0.0
-		if success {
-			value = 1.0
+		success := 0.0
+		if result.success {
+			success = 1.0
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.lastScrapeSuccessDesc,
 			prometheus.GaugeValue,
-			value,
+			success,
 			name,
 		)
 	}

--- a/internal/collector/scrape_health_test.go
+++ b/internal/collector/scrape_health_test.go
@@ -58,7 +58,7 @@ func TestRecordScrapeResultFailureIncrementsErrorCounter(t *testing.T) {
 		"error counter should accumulate across failed scrapes, not just reflect the latest one")
 
 	c.mutex.Lock()
-	success := c.lastScrapeSuccess["definitions_roster"]
+	success := c.scrapeResults["definitions_roster"].success
 	c.mutex.Unlock()
 	assert.False(t, success)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,26 +13,26 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func RunServer(ctx context.Context, config *config.Config) {
-	portSuffix := fmt.Sprintf(":%d", config.Port)
-	c := collector.NewDagsterCollector(ctx, config.DagsterGraphQLEndpoint, config.LookbackWindow, config.CacheTTL, config.RunsPageSize, config.RunsUpdatedAfterSafetyMargin)
+func RunServer(ctx context.Context, cfg *config.Config) {
+	portSuffix := fmt.Sprintf(":%d", cfg.Port)
+	c := collector.NewDagsterCollector(ctx, cfg.DagsterGraphQLEndpoint, cfg.LookbackWindow, cfg.CacheTTL, cfg.RunsPageSize, cfg.RunsUpdatedAfterSafetyMargin)
 	prometheus.MustRegister(c)
 	registerBuildInfo()
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/healthz", healthzHandler)
-	mux.Handle("/readyz", newReadyzHandler(config.DagsterGraphQLEndpoint, config.DagsterScrapingTimeout))
+	mux.Handle("/readyz", newReadyzHandler(cfg.DagsterGraphQLEndpoint, cfg.DagsterScrapingTimeout))
 
 	srv := &http.Server{
 		Addr:    portSuffix,
 		Handler: mux,
 	}
 
-	go startScrape(ctx, c, config.DagsterScrapingInterval, config.DagsterScrapingTimeout)
+	go startScrape(ctx, c, cfg.DagsterScrapingInterval, cfg.DagsterScrapingTimeout)
 
 	go func() {
-		log.Printf("Starting Prometheus metrics server on port %d", config.Port)
+		log.Printf("Starting Prometheus metrics server on port %d", cfg.Port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("HTTP server ListenAndServe failed: %v", err)
 		}


### PR DESCRIPTION
> [!IMPORTANT]
> **Breaking metric change**: the placeholder location label value changes from `unknown` to `__unknown__`. See that item under *Why* for the reasoning and why now.

## What

Three of the seven items from #72, the documentation they touch, and a lint configuration that enforces one of them. The other four items are resolved rather than implemented — see *The four not done*.

| Item | Change |
|---|---|
| Duplicated location extraction | `Run.location()`, replacing the same four lines in `CollectActiveRuns` and `CollectCompletedRuns` |
| Two parallel maps | `scrapeDuration` + `lastScrapeSuccess` → one `map[string]scrapeResult` |
| Shadowed package name | `config` → `cfg` in `main` **and** in `RunServer`, plus a lint rule so it can't recur |
| Placeholder collision | `unknown` → `__unknown__`, and documented |

Also updates the README's one-line summary, adds the placeholder to `docs/metrics.md`, and moves `unknownLocationName` from `collector.go` to `graphql.go`, next to `Run.location()` — its only non-test user.

## Why

**`Run.location()`** — the "read `repositoryOrigin`, fall back to a placeholder" block was written out twice. It belongs on the type it reads.

**One scrape-result map** — `scrapeDuration` and `lastScrapeSuccess` were always written together by `RecordScrapeResult` and always read together by `reflectScrapeHealth`, keyed identically. One map of a struct removes the possibility of the two disagreeing about which collectors exist, and lets the reflect function iterate once instead of twice.

**`cfg`, and `.golangci.yml`** — `config, err := config.Load()` shadowed the imported package for the rest of `main`. The damage is not to the working code but to the next person: once shadowed, using the package again fails with `config.Config is not a type`, which says nothing about the shadowing that caused it.

`main.go` was the visible case. Running gocritic's `importShadow` turned up a second one nobody had noticed — `RunServer(ctx context.Context, config *config.Config)`, where the *parameter* shadows the package for the whole body. Since the class of problem is invisible by inspection, the check is now enabled in a new `.golangci.yml` rather than left to the eye.

That file also pins the linter set itself. Until now there was no config, so golangci-lint ran whatever its own version enabled by default — which is exactly how a local v1 install and a CI v2 install came to check different things (the gap that made a clean local run inconclusive during #69, addressed from the version side by #79). Declaring `version: "2"` has a useful side effect: v1 refuses to run against it —

```
Error: you are using a configuration file for golangci-lint v2 with golangci-lint v1: please use golangci-lint v2
```

— rather than silently applying a different set. With `.tool-versions`, a local run now either matches CI or fails loudly.

**`__unknown__`** — this is the one with user-visible impact. The placeholder marks runs whose `repositoryOrigin` is absent. If a real code location were named `unknown`, two different facts would collapse into one label value:

```
location="unknown"  <-  repositoryOrigin not recorded (we don't know where this ran)
location="unknown"  <-  ran in the code location actually named "unknown"
```

`dagster_completed_runs_total{location="unknown"}` would sum both, with no way to separate them. There's a second effect too: `pruneLastRunStatus` and `pruneCompletedRunsCounter` delete keys absent from `knownJobs`, so today placeholder entries are always cleaned up on the next roster scrape — precisely because no live location is called `unknown`. A real location with that name would make stale placeholder entries look live and keep them forever.

Doing it now rather than deferring: the project is pre-1.0 (`v0.2.0`), which is the version range where this is expected, and the placeholder series is short-lived anyway since it gets pruned on the next roster scrape — so there is very little for anyone to have built on. It gets more expensive to fix every release.

`docs/metrics.md` never mentioned the placeholder at all; it now explains what it means, why the name is shaped that way, and notes the old value.

## The four not done

**`elapsedSince` truncating sub-second precision — not a defect.** #72 listed it as one. Reconsidered: the value is computed once per scrape and then served unchanged until the next one, so by the time Prometheus reads it, it is already up to a full scrape interval (15s by default) out of date. A sub-second correction is lost inside that, and the consumers are "queued longer than 10 minutes" style alerts rather than stopwatch readings. Fixing it meant a scaling constant and a paragraph about `int64` overflow windows in exchange for precision nobody can observe.

The function ends up byte-identical to `main`. What is new is a comment recording that the truncation is deliberate and why, so the next reader doesn't re-open the question and land on a fix that buys nothing.

**Collapsing the per-`reflect` locking into `Collect` — decided against.** Also proposed in #72; on closer look it doesn't pay:

- The gain is 9 mutex round-trips per scrape instead of 1, which is not measurable here.
- The cost is a new implicit contract ("callers must hold `c.mutex`") on nine functions that are currently self-contained and impossible to misuse, plus updating the six tests that call `reflect*` directly.
- The "consistent snapshot" argument in the issue doesn't hold either: the four collectors write at different times regardless, so a single lock around `Collect` still can't make the families come from one scrape generation.

**`concurrencyKeyBacklog` growing without bound → split out as #81.** It needs a design decision (document the assumption, cap, expire by age, or drop the zero-fill) rather than a mechanical fix.

## QA

- `go build` / `go vet` / `gofmt` / `go test -race` / `golangci-lint` all clean, the last one now running the repository's own config.
- Confirmed the new lint rule has teeth by reintroducing the `RunServer` shadowing: `importShadow: shadow of imported ... package 'config'`, and clean again once reverted.
- Confirmed the v1 refusal quoted above, by running the older local binary against the v2 config.
- `TestRunLocationFallsBackWhenOriginIsAbsent` covers both branches of the new method.
- No test hardcoded the placeholder string (they all referenced `unknownLocationName`), so the label change is covered by the existing suite without edits.
- Verified the README's new summary against `docs/metrics.md`: all eleven metric families are now represented, where the old wording covered only run counts, statuses and code locations.

## Ref

Closes #72. Split out: #81.