### PR TITLE
Ask for ticks in a way Dagster answers, so the tick status metrics work at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,17 @@ dagster_code_location_load_error{location="dev-dagster-location"} 0
 
 ### Testing schedule/sensor tick status
 
-Unlike the broken-code-location fixture above, these aren't opt-in: `dev/dagster_workspace/job.py` defines `quick_job_schedule` (cron `* * * * *`, `default_status=DefaultScheduleStatus.RUNNING`) and `quick_job_sensor` (`minimum_interval_seconds=30`, `default_status=DefaultSensorStatus.RUNNING`, always returns a `SkipReason`) against a near-instant job, so the standard dev stack (`docker compose up`) starts ticking both automatically — no extra setup needed to see `dagster_schedule_status`/`dagster_schedule_last_tick_status`/`dagster_sensor_status`/`dagster_sensor_last_tick_status` report real data within about a minute of startup.
+Unlike the broken-code-location fixture above, these aren't opt-in. `dev/dagster_workspace/job.py` defines three instigators against a near-instant job, all with `default_status=RUNNING`, so the standard dev stack (`docker compose up`) starts ticking them automatically — no extra setup needed to see `dagster_schedule_status`/`dagster_schedule_last_tick_status`/`dagster_sensor_status`/`dagster_sensor_last_tick_status` report real data within a couple of minutes of startup.
+
+Each produces a different tick status, so all three show up at once and an alert written against the `status` label can be tried out locally:
+
+| Fixture | Tick status | Why |
+| --- | --- | --- |
+| `quick_job_schedule` | `success` | cron `* * * * *`, launches `quick_job` every minute |
+| `quick_job_sensor` | `skipped` | `minimum_interval_seconds=30`, always returns a `SkipReason` |
+| `failing_sensor` | `failure` | `minimum_interval_seconds=30`, always raises |
+
+`failing_sensor` logs an error on every evaluation by design — intentional, like `failing_job` and the broken code location, not a sign the dev stack is misconfigured.
 
 ### Testing the Helm chart against a real Dagster (kind)
 

--- a/dev/dagster_workspace/job.py
+++ b/dev/dagster_workspace/job.py
@@ -70,4 +70,20 @@ def quick_job_sensor(context: SensorEvaluationContext):
     )
 
 
-sensors = [quick_job_sensor]
+# Also default_status=RUNNING. Raises instead of returning, so its ticks are
+# deterministically FAILURE — the third distinct tick status alongside the
+# schedule's SUCCESS and quick_job_sensor's SKIPPED. Without it, nothing in
+# the dev stack ever produces dagster_sensor_last_tick_status{status="failure"},
+# so an alert written against that label can't be tried out locally.
+#
+# It logs an error every evaluation interval by design, in the same spirit as
+# failing_job and the broken code location: intentional, named to say so.
+@sensor(job=quick_job, minimum_interval_seconds=30, default_status=DefaultSensorStatus.RUNNING)
+def failing_sensor(context: SensorEvaluationContext):
+    raise RuntimeError(
+        "dev fixture: intentionally always fails, for exercising "
+        "dagster_sensor_last_tick_status{status=\"failure\"}"
+    )
+
+
+sensors = [quick_job_sensor, failing_sensor]

--- a/internal/collector/definitions_roster_test.go
+++ b/internal/collector/definitions_roster_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -205,4 +206,59 @@ func TestCollectDefinitionsRosterTracksScheduleStatusAndLastTick(t *testing.T) {
 	assert.Equal(t, "my_schedule", labels["schedule_name"])
 	assert.Equal(t, "loc_a", labels["location"])
 	assert.Equal(t, "success", labels["status"])
+}
+
+// Dagster's InstigationState.ticks returns an empty list when asked with a
+// limit but no time bound, which is how the tick metrics came to be silently
+// absent on every real instance (issue #85). The other tests here can't catch
+// that, because their mocks hand back ticks regardless of what was asked.
+//
+// This server mimics the real resolver: ticks come back only if the query
+// carried a time bound.
+func TestCollectDefinitionsRosterAsksForTicksInAWayDagsterAnswers(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		// Comments in the query mention afterTimestamp by name, so match on
+		// the argument itself rather than the word appearing anywhere.
+		var args strings.Builder
+		for line := range strings.SplitSeq(req.Query, "\n") {
+			if !strings.HasPrefix(strings.TrimSpace(line), "#") {
+				args.WriteString(line)
+			}
+		}
+		bounded := strings.Contains(args.String(), "afterTimestamp:") || strings.Contains(args.String(), "dayRange:")
+
+		ticks := "[]"
+		if bounded {
+			ticks = `[{"status": "SUCCESS", "timestamp": 200}]`
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+			"data": {
+				"repositoriesOrError": {
+					"__typename": "RepositoryConnection",
+					"nodes": [
+						{
+							"name": "repo", "location": {"name": "loc_a"}, "jobs": [],
+							"schedules": [{"name": "sched_a", "cronSchedule": "* * * * *", "scheduleState": {"status": "RUNNING", "ticks": ` + ticks + `}}],
+							"sensors": [{"name": "sensor_a", "sensorState": {"status": "RUNNING", "ticks": ` + ticks + `}}]
+						}
+					]
+				}
+			}
+		}`))
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+	require.NoError(t, CollectDefinitionsRoster(t.Context(), c))
+
+	assert.Contains(t, c.scheduleTickStatus, ScheduleKey{ScheduleName: "sched_a", LocationName: "loc_a"},
+		"the roster query must ask for ticks in a way Dagster actually answers; a bare limit returns nothing")
+	assert.Contains(t, c.sensorTickStatus, SensorKey{SensorName: "sensor_a", LocationName: "loc_a"})
 }

--- a/internal/collector/queries/get_definitions_roster.graphql
+++ b/internal/collector/queries/get_definitions_roster.graphql
@@ -15,7 +15,14 @@ query GetDefinitionsRoster {
           cronSchedule
           scheduleState {
             status
-            ticks(limit: 1) {
+            # afterTimestamp is required for limit to do anything: asking for
+            # ticks(limit: 1) alone returns an empty list, and afterTimestamp: 0
+            # reads as "not specified" rather than "since the epoch". 1 is one
+            # second after the epoch, so this is an unbounded lookback that
+            # returns only the newest tick — which is what the metric means.
+            # A bounded window (dayRange) would drop infrequent schedules out
+            # of the metric for most of their cycle. See issues #85 and #86.
+            ticks(limit: 1, afterTimestamp: 1) {
               status
               timestamp
             }
@@ -25,7 +32,14 @@ query GetDefinitionsRoster {
           name
           sensorState {
             status
-            ticks(limit: 1) {
+            # afterTimestamp is required for limit to do anything: asking for
+            # ticks(limit: 1) alone returns an empty list, and afterTimestamp: 0
+            # reads as "not specified" rather than "since the epoch". 1 is one
+            # second after the epoch, so this is an unbounded lookback that
+            # returns only the newest tick — which is what the metric means.
+            # A bounded window (dayRange) would drop infrequent schedules out
+            # of the metric for most of their cycle. See issues #85 and #86.
+            ticks(limit: 1, afterTimestamp: 1) {
               status
               timestamp
             }

--- a/internal/collector/schedules.go
+++ b/internal/collector/schedules.go
@@ -14,7 +14,7 @@ type ScheduleKey struct {
 // scheduleTickEntry tracks the status of a schedule's most recently
 // observed tick, for dagster_schedule_last_tick_status. timestamp isn't
 // currently exposed as a metric itself, but is kept alongside status since
-// it's what "most recent" is determined by (ticks(limit: 1) already returns
+// it's what "most recent" is determined by (ticks(limit: 1, afterTimestamp: 1) already returns
 // newest-first, so this is mostly for future use/debugging).
 type scheduleTickEntry struct {
 	status    string
@@ -34,7 +34,7 @@ func buildScheduleState(resp *GraphQLDefinitionsRosterResponse) (map[ScheduleKey
 			key := ScheduleKey{ScheduleName: schedule.Name, LocationName: repo.Location.Name}
 			status[key] = schedule.ScheduleState.Status
 
-			// ticks(limit: 1) returns the single most recent tick, newest
+			// ticks(limit: 1, afterTimestamp: 1) returns the single most recent tick, newest
 			// first; a schedule that has never fired yet returns an empty
 			// list, and simply has no entry here (no seeded value — same
 			// rationale as dagster_last_run_info for a job that's never run).

--- a/internal/collector/sensors.go
+++ b/internal/collector/sensors.go
@@ -33,7 +33,7 @@ func buildSensorState(resp *GraphQLDefinitionsRosterResponse) (map[SensorKey]str
 			key := SensorKey{SensorName: sensor.Name, LocationName: repo.Location.Name}
 			status[key] = sensor.SensorState.Status
 
-			// ticks(limit: 1) returns the single most recent tick, newest
+			// ticks(limit: 1, afterTimestamp: 1) returns the single most recent tick, newest
 			// first; a sensor that has never fired yet returns an empty
 			// list, and simply has no entry here (no seeded value — same
 			// rationale as dagster_last_run_info for a job that's never run).


### PR DESCRIPTION
## What

Change the roster query from `ticks(limit: 1)` to `ticks(limit: 1, afterTimestamp: 1)`, add a test that would have caught the difference, add a deliberately failing sensor to the dev fixture, and correct the README claim that the tick metrics report real data out of the box.

## Why

`dagster_schedule_last_tick_status` and `dagster_sensor_last_tick_status` have **never produced a single series against a real Dagster instance**, since #54/#55 added them.

Against the standard dev stack, with the daemon demonstrably doing the work:

```
SchedulerDaemon - Evaluating schedule `quick_job_schedule` at 2026-08-15 05:26:00 +0000
SchedulerDaemon - Completed scheduled launch of run 20ff31e7-... for quick_job_schedule
SensorDaemon    - Sensor quick_job_sensor skipped: dev fixture: intentionally always skips
```

the exporter reported only:

```
dagster_schedule_status{...,status="running"} 1
dagster_sensor_status{...,status="running"} 1
```

On `InstigationState`, `limit` needs a time bound to do anything. Measured against Dagster 1.13.15:

| Arguments | Ticks returned |
|---|---|
| `limit: 1` | **0** |
| `limit: 5` | **0** |
| `limit: 1, afterTimestamp: 0` | **0** |
| `dayRange: 1` | 37 |
| `afterTimestamp: 0` (no `limit`) | 45 |
| `limit: 1, dayRange: 1` | 1 |
| `limit: 1, afterTimestamp: 1` | 1 |

`afterTimestamp: 0` reads as "not specified" rather than "since the epoch", so `1` — one second past it — is the smallest value that gives an unbounded lookback. That is what these metrics want: they report *what the most recent tick was*, so a schedule that last ticked a month ago should still report it.

A bounded window was considered and rejected. `dayRange: N`, or a window sized off the scraping interval, drops infrequent schedules out of the metric for most of their cycle — the series would flap between present and absent for reasons unrelated to health. Fetch volume isn't a reason to bound it either: `limit: 1` already does that (45 ticks unbounded without a limit, 1 with it). Whether the *server-side* cost differs is a real question, split out as #86 rather than guessed at here.

## The test that didn't work

The original tests missed this because their mocks return a `ticks` array regardless of what the query asked — the mock has no notion of the arguments the real resolver requires. Same shape as #69: a response that decodes into a well-formed but empty result, with nothing asserting real Dagster would have filled it.

The new test mimics the resolver, returning ticks only when the query carries a time bound. Worth flagging that **the first version of this test passed with the fix reverted**: the query's own explanatory comment mentions `afterTimestamp` by name, and a `strings.Contains(query, "afterTimestamp")` check matched the comment. It now strips comment lines and matches on `afterTimestamp:` as an argument. Caught only by actually reverting the fix and watching the test — not by writing it and seeing green.

## The dev fixture could only produce two of the statuses

`quick_job_schedule` ticks `success` and `quick_job_sensor` ticks `skipped`, so nothing in the dev stack ever produced `status="failure"` and no alert written against that label could be tried locally. `failing_sensor` raises on every evaluation, giving the third. It logs an error every interval by design — intentional, in the same spirit as `failing_job` and the broken code location.

## QA

Verified end to end against the dev stack (Dagster 1.13.15), all three statuses present at once:

```
dagster_schedule_last_tick_status{schedule_name="quick_job_schedule",status="success"} 1
dagster_sensor_last_tick_status{sensor_name="quick_job_sensor",status="skipped"} 1
dagster_sensor_last_tick_status{sensor_name="failing_sensor",status="failure"} 1
```

Confirmed the regression test fails with the query reverted:

```
--- FAIL: TestCollectDefinitionsRosterAsksForTicksInAWayDagsterAnswers
    Messages: the roster query must ask for ticks in a way Dagster actually answers; a bare limit returns nothing
```

`go build` / `go vet` / `gofmt` / `go test -race` / `golangci-lint` / `ruff` all clean.

## Ref

Closes #85. Follow-up: #86 (server-side cost of the unbounded lookback). Unblocks #84, whose tick-timestamp metric is derived from the same data.