### PR TITLE
Add daemon health metrics, so a dead scheduler is visible at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ flowchart LR
     Grafana -- query --> Prometheus
 ```
 
-A single Go binary with no external state store: it polls Dagster's GraphQL API on an interval, keeps the result in memory, and serves it from `/metrics`. Scraping (writing that state) and serving `/metrics` (reading it) are decoupled, so a slow or failing Dagster GraphQL call never blocks or breaks a `/metrics` request — it just serves the last known state. Four collectors (definitions roster, active runs, completed runs, code-location load status) run concurrently on every scrape.
+A single Go binary with no external state store: it polls Dagster's GraphQL API on an interval, keeps the result in memory, and serves it from `/metrics`. Scraping (writing that state) and serving `/metrics` (reading it) are decoupled, so a slow or failing Dagster GraphQL call never blocks or breaks a `/metrics` request — it just serves the last known state. Five collectors (definitions roster, active runs, completed runs, code-location load status, daemon health) run concurrently on every scrape.
 
 For the package layout, why there are four separate collectors, and how completed-run fetching stays incremental instead of re-scanning everything every cycle, see [docs/architecture.md](docs/architecture.md).
 
@@ -88,6 +88,8 @@ Full label reference, edge cases, and design rationale for every metric below: [
 | `dagster_completed_runs_total` | Counter | Completed runs (`success`/`failure`) per job, since the exporter started. |
 | `dagster_last_run_info` | Gauge | Status of each job's most recently completed run (always `1`; status is in the `status` label). |
 | `dagster_last_run_duration_seconds` | Gauge | Duration of each job's most recently completed run. |
+| `dagster_daemon_healthy` | Gauge | Whether each Dagster daemon is alive — the only metric that sees a dead scheduler. |
+| `dagster_daemon_last_heartbeat_timestamp_seconds` | Gauge | When each daemon last reported a heartbeat. |
 | `dagster_code_location_load_error` | Gauge | Whether a code location most recently failed to load. |
 | `dagster_run_queue_concurrency_key_backlog` | Gauge | Runs queued behind a tag-based run-queue concurrency limit, per `dagster/concurrency_key` value. |
 | `dagster_schedule_status` | Gauge | Whether a schedule is currently on or off. |

--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -641,6 +641,97 @@
         "x": 18,
         "y": 21
       }
+    },
+    {
+      "title": "Daemon Health",
+      "description": "The only panel that shows a dead scheduler. Every other panel keeps looking healthy when the daemon dies, because they are all served by the webserver.",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "dagster_daemon_healthy",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "Down",
+                        "color": "red"
+                      },
+                      "1": {
+                        "text": "Healthy",
+                        "color": "green"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      }
+    },
+    {
+      "title": "Daemon Heartbeat Age",
+      "description": "Seconds since each daemon last reported a heartbeat. Computed at query time from the exported timestamp, so it keeps climbing while a daemon is down instead of freezing at the last scrape.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "time() - dagster_daemon_last_heartbeat_timestamp_seconds",
+          "legendFormat": "{{daemon_type}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      }
     }
   ],
   "templating": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,11 +13,13 @@ The exporter is a single Go binary with no external state store — everything i
 
 Because scraping (writing state) and metrics rendering (reading state) are decoupled, a slow or failing Dagster GraphQL call never blocks or breaks a `/metrics` request — it just serves the last known state.
 
-## Why four collectors, and why they're split the way they are
+## Why five collectors, and why they're split the way they are
 
-The four collectors (definitions roster, active runs, completed runs, code-location load status) run concurrently on every scrape — each locks `DagsterCollector`'s own mutex only around its own critical section, so they don't block each other or `/metrics`.
+The five collectors (definitions roster, active runs, completed runs, code-location load status, daemon health) run concurrently on every scrape — each locks `DagsterCollector`'s own mutex only around its own critical section, so they don't block each other or `/metrics`.
 
 The code-location load status collector is intentionally independent of the definitions-roster one: `repositoriesOrError` (used for the roster) silently omits a code location that fails to load rather than erroring out, so a separate `workspaceOrError` query is needed to detect that failure at all — see `dagster_code_location_load_error` in the [metrics reference](metrics.md).
+
+The daemon-health collector is likewise independent: `instance.daemonHealth` is a top-level field, not something reachable from `repositoriesOrError`, so it needs its own query. It is also the only collector that reports on Dagster's *machinery* rather than its work — everything else here describes runs, schedules, sensors and code locations, all of which the webserver keeps answering perfectly while the daemon is down.
 
 `dagster_run_queue_concurrency_key_backlog` is folded into the active-runs collector instead of getting its own: it only needs `QUEUED` runs' tags, which that collector already fetches on every page, so a separate query would just re-fetch the same runs a second time for no reason.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -50,6 +50,45 @@ Labels: `location`
 
 A code location can fail to load independently of any job/run activity — `dagster_active_runs`/`dagster_completed_runs_total` alone can't distinguish "this location has zero jobs" from "this location is broken," so this metric exists to surface that failure mode explicitly. The load-error message and stack trace are logged, not attached as a label, to avoid unbounded label cardinality.
 
+## `dagster_daemon_healthy` (Gauge)
+
+Labels: `daemon_type`, `required`
+
+`1` if the daemon is currently healthy, `0` otherwise. `daemon_type` is one of Dagster's daemons — on 1.13.15: `SCHEDULER`, `SENSOR`, `BACKFILL`, `QUEUED_RUN_COORDINATOR`, `ASSET`, `FRESHNESS_DAEMON`.
+
+This is the only metric here that reports on Dagster's machinery rather than its work, and it answers a question none of the others can: **is the scheduler actually running?** When the daemon dies, everything else keeps looking healthy — `dagster_schedule_status` still reports `running` (the schedule *is* enabled; that metric is about the on/off state, not the daemon), the last tick status stays frozen at whatever it was, active runs simply go quiet, and `dagster_exporter_last_scrape_success` stays `1` because the GraphQL endpoint is served by the webserver, which is fine. Nothing changes. Without this metric, "the scheduler is dead" and "nothing was scheduled" are indistinguishable.
+
+`required=false` means the instance isn't configured to run that daemon, so it reporting unhealthy is expected rather than an incident — scope any alert to `{required="true"}`.
+
+A null `healthy` from Dagster is reported as `0`, not `1`: this metric exists to catch a daemon that isn't answering, and no answer is not an answer.
+
+`lastHeartbeatErrors` is logged rather than attached as a label, the same treatment `dagster_code_location_load_error` gives its error message, to avoid unbounded label cardinality.
+
+**Don't alert on this metric alone.** `healthy` is not a live check — it is Dagster comparing the last heartbeat against a fixed 30-minute tolerance (`DEFAULT_DAEMON_HEARTBEAT_TOLERANCE_SECONDS = 1800`, against a `DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30` write interval). A daemon that stopped 14 minutes ago still reports `1`. Verified by freezing the daemon process with `SIGSTOP` while leaving the webserver up:
+
+```
+dagster_daemon_healthy{daemon_type="SCHEDULER",required="true"} 1     # after 14 minutes down
+time() - dagster_daemon_last_heartbeat_timestamp_seconds  ->  825     # and climbing
+```
+
+For an every-minute schedule that tolerance means roughly thirty missed runs before anything fires. Use the heartbeat timestamp below and pick your own threshold.
+
+## `dagster_daemon_last_heartbeat_timestamp_seconds` (Gauge)
+
+Labels: `daemon_type`
+
+Unix timestamp of the daemon's most recent heartbeat, exported as a timestamp rather than an age so staleness is computed at query time (`time() - dagster_daemon_last_heartbeat_timestamp_seconds`) instead of being frozen at scrape time.
+
+A daemon that has never reported a heartbeat produces no series at all, rather than one claiming a heartbeat at the Unix epoch — which would make every staleness alert fire on a freshly started instance.
+
+This, rather than `dagster_daemon_healthy`, is the metric to alert on. Heartbeats are written every 30s, so a threshold of a couple of minutes catches a stopped daemon roughly fifteen times sooner than Dagster's own 30-minute tolerance:
+
+```promql
+time() - dagster_daemon_last_heartbeat_timestamp_seconds{daemon_type="SCHEDULER"} > 120
+```
+
+Exporting the raw timestamp is what makes that choice yours: an exported age would be computed once per scrape and then served unchanged, so it would understate the outage by up to a full scrape interval.
+
 ## `dagster_run_queue_concurrency_key_backlog` (Gauge)
 
 Labels: `concurrency_key`
@@ -86,7 +125,7 @@ Same as `dagster_schedule_last_tick_status`, for sensors. Note a sensor tick tha
 
 ## Exporter self-health
 
-These report on the exporter itself, rather than on Dagster's run state. The first three are about whether its own scrapes of Dagster are succeeding, and are labeled `collector`, one of `definitions_roster`, `active_runs`, `completed_runs`, or `code_location_status` (the four concurrent collectors described in [docs/architecture.md](architecture.md)).
+These report on the exporter itself, rather than on Dagster's run state. The first three are about whether its own scrapes of Dagster are succeeding, and are labeled `collector`, one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status`, or `daemon_health` (the five concurrent collectors described in [docs/architecture.md](architecture.md)).
 
 ### `dagster_exporter_scrape_duration_seconds` (Gauge)
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -26,6 +26,8 @@ type DagsterCollector struct {
 	scheduleTickStatusDesc    *prometheus.Desc
 	sensorStatusDesc          *prometheus.Desc
 	sensorTickStatusDesc      *prometheus.Desc
+	daemonHealthyDesc         *prometheus.Desc
+	daemonLastHeartbeatDesc   *prometheus.Desc
 
 	mutex                   sync.Mutex
 	activeRunAggregates     map[ActiveRunKey]activeRunAggregate
@@ -43,6 +45,7 @@ type DagsterCollector struct {
 	runsPageSize            int
 	scrapeResults           map[string]scrapeResult
 	codeLocationLoadError   map[string]bool
+	daemonHealth            map[string]daemonHealthEntry
 	// runsUpdatedAfterSafetyMargin is subtracted from the last-seen
 	// updateTime watermark before it's used as the next scrape's
 	// updatedAfter. A run's updateTime can be set slightly before its write
@@ -160,6 +163,18 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"sensor_name", "location", "status"},
 			nil,
 		),
+		daemonHealthyDesc: prometheus.NewDesc(
+			"dagster_daemon_healthy",
+			"Whether a Dagster daemon is currently healthy (1) or not (0). required=false means the instance isn't configured to run it, so it being unhealthy is expected rather than an incident",
+			[]string{"daemon_type", "required"},
+			nil,
+		),
+		daemonLastHeartbeatDesc: prometheus.NewDesc(
+			"dagster_daemon_last_heartbeat_timestamp_seconds",
+			"Unix timestamp of a daemon's most recent heartbeat. Absent for a daemon that has never reported one. Exported as a timestamp rather than an age so staleness is computed at query time (time() - metric), not frozen at scrape time",
+			[]string{"daemon_type"},
+			nil,
+		),
 		processedRuns:                cache,
 		lookbackWindow:               lookbackWindow,
 		lastRunStatus:                make(map[JobKey]lastRunEntry),
@@ -183,6 +198,8 @@ func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.scheduleTickStatusDesc
 	ch <- c.sensorStatusDesc
 	ch <- c.sensorTickStatusDesc
+	ch <- c.daemonHealthyDesc
+	ch <- c.daemonLastHeartbeatDesc
 	c.completedRunsCounter.Describe(ch)
 	c.scrapeErrorsCounter.Describe(ch)
 }
@@ -197,6 +214,7 @@ func (c *DagsterCollector) Collect(ch chan<- prometheus.Metric) {
 	reflectScheduleTickStatus(c, ch)
 	reflectSensorStatus(c, ch)
 	reflectSensorTickStatus(c, ch)
+	reflectDaemonHealth(c, ch)
 	c.completedRunsCounter.Collect(ch)
 	c.scrapeErrorsCounter.Collect(ch)
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -23,9 +23,10 @@ func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
 	// activeRunsDesc, lastRunStatusDesc, scrapeDurationDesc, lastScrapeSuccessDesc,
 	// codeLocationLoadErrorDesc, lastRunDurationDesc, activeRunDurationDesc,
 	// concurrencyKeyBacklogDesc, scheduleStatusDesc, scheduleTickStatusDesc,
-	// sensorStatusDesc, sensorTickStatusDesc, plus one each from
-	// completedRunsCounter and scrapeErrorsCounter.
-	assert.Equal(t, 14, descCount)
+	// sensorStatusDesc, sensorTickStatusDesc, daemonHealthyDesc,
+	// daemonLastHeartbeatDesc, plus one each from completedRunsCounter and
+	// scrapeErrorsCounter.
+	assert.Equal(t, 16, descCount)
 
 	c.RecordScrapeResult("active_runs", 10*time.Millisecond, nil)
 

--- a/internal/collector/daemon_health.go
+++ b/internal/collector/daemon_health.go
@@ -1,0 +1,120 @@
+package collector
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// daemonHealthEntry is one Dagster daemon's most recently reported state.
+//
+// lastHeartbeat is a pointer because a daemon that has never reported one has
+// no timestamp rather than a zero — emitting 0 would place its last heartbeat
+// at the Unix epoch and make every staleness alert fire.
+type daemonHealthEntry struct {
+	required      bool
+	healthy       bool
+	lastHeartbeat *float64
+}
+
+// CollectDaemonHealth reports whether Dagster's daemons are alive.
+//
+// This is the one question none of the other collectors can answer. Everything
+// else here describes Dagster's *work* — runs, schedules, sensors, code
+// locations — and all of it is served by the webserver, which stays perfectly
+// healthy when the daemon dies. A dead SCHEDULER just means schedules stop
+// firing: dagster_schedule_status still reports running, the last tick status
+// stays frozen at whatever it was, and dagster_exporter_last_scrape_success
+// stays 1. Nothing in /metrics changes.
+//
+// It deliberately doesn't rely on schedule/sensor tick recency to infer this
+// (see dagster_schedule_last_tick_timestamp_seconds, which is useful for a
+// different question). Tick recency says nothing at all in a deployment that
+// launches everything manually or through the API, and daemon liveness
+// shouldn't depend on whether the user happens to have defined a sensor.
+//
+// instance.daemonHealth is a top-level field rather than something reachable
+// from repositoriesOrError, so this is its own query and its own collector —
+// the same reasoning as CollectCodeLocationStatus.
+func CollectDaemonHealth(ctx context.Context, c *DagsterCollector) error {
+	req := getDaemonHealthRequest()
+
+	resp, err := getDaemonHealth(ctx, req, c.dagsterGraphQLEndpoint)
+	if err != nil {
+		log.Printf("failed to collect daemon health from dagster: %v", err)
+		return err
+	}
+
+	statuses := resp.Data.Instance.DaemonHealth.AllDaemonStatuses
+	entries := make(map[string]daemonHealthEntry, len(statuses))
+	for _, status := range statuses {
+		// healthy is nullable in the schema. Treat an absent value as
+		// unhealthy rather than healthy: this metric exists to catch a daemon
+		// that isn't reporting, and "no answer" is not an answer.
+		healthy := status.Healthy != nil && *status.Healthy
+
+		entries[status.DaemonType] = daemonHealthEntry{
+			required:      status.Required,
+			healthy:       healthy,
+			lastHeartbeat: status.LastHeartbeatTime,
+		}
+
+		if len(status.LastHeartbeatErrors) > 0 {
+			messages := make([]string, 0, len(status.LastHeartbeatErrors))
+			for _, e := range status.LastHeartbeatErrors {
+				messages = append(messages, e.Message)
+			}
+			// Logged rather than labeled, the same treatment
+			// dagster_code_location_load_error gives its error message: the
+			// text is unbounded and would blow up label cardinality.
+			log.Printf("dagster daemon %q reported heartbeat errors: %s", status.DaemonType, strings.Join(messages, "; "))
+		}
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.daemonHealth = entries
+
+	return nil
+}
+
+// reflectDaemonHealth emits dagster_daemon_healthy and
+// dagster_daemon_last_heartbeat_timestamp_seconds from a single locked pass,
+// the same reasoning as reflectLastRun: both come from one entry.
+func reflectDaemonHealth(c *DagsterCollector, ch chan<- prometheus.Metric) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for daemonType, entry := range c.daemonHealth {
+		healthy := 0.0
+		if entry.healthy {
+			healthy = 1.0
+		}
+		required := "false"
+		if entry.required {
+			required = "true"
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.daemonHealthyDesc,
+			prometheus.GaugeValue,
+			healthy,
+			daemonType,
+			required,
+		)
+
+		// A daemon that has never reported a heartbeat gets no series at all,
+		// rather than one claiming a heartbeat at the epoch.
+		if entry.lastHeartbeat != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.daemonLastHeartbeatDesc,
+				prometheus.GaugeValue,
+				*entry.lastHeartbeat,
+				daemonType,
+			)
+		}
+	}
+}

--- a/internal/collector/daemon_health_test.go
+++ b/internal/collector/daemon_health_test.go
@@ -1,0 +1,113 @@
+package collector
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// daemonHealthBody mirrors what a live Dagster 1.13.15 returns, including the
+// nullable fields: a daemon that has never reported a heartbeat, and one
+// whose healthy flag is absent entirely.
+const daemonHealthBody = `{
+	"data": {
+		"instance": {
+			"daemonHealth": {
+				"allDaemonStatuses": [
+					{"daemonType": "SCHEDULER", "required": true, "healthy": true, "lastHeartbeatTime": 1786766271.6, "lastHeartbeatErrors": []},
+					{"daemonType": "SENSOR", "required": true, "healthy": false, "lastHeartbeatTime": 1786766200.1, "lastHeartbeatErrors": [{"message": "boom"}]},
+					{"daemonType": "BACKFILL", "required": false, "healthy": null, "lastHeartbeatTime": null, "lastHeartbeatErrors": []}
+				]
+			}
+		}
+	}
+}`
+
+func daemonHealthServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(body))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestCollectDaemonHealth(t *testing.T) {
+	ts := daemonHealthServer(t, daemonHealthBody)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	require.NoError(t, CollectDaemonHealth(t.Context(), c))
+
+	require.Len(t, c.daemonHealth, 3)
+	assert.True(t, c.daemonHealth["SCHEDULER"].healthy)
+	assert.False(t, c.daemonHealth["SENSOR"].healthy)
+	assert.False(t, c.daemonHealth["BACKFILL"].healthy,
+		"a null healthy flag means the daemon isn't answering, which is not the same as healthy")
+
+	assert.True(t, c.daemonHealth["SCHEDULER"].required)
+	assert.False(t, c.daemonHealth["BACKFILL"].required)
+
+	require.NotNil(t, c.daemonHealth["SCHEDULER"].lastHeartbeat)
+	assert.InDelta(t, 1786766271.6, *c.daemonHealth["SCHEDULER"].lastHeartbeat, 1e-6)
+	assert.Nil(t, c.daemonHealth["BACKFILL"].lastHeartbeat,
+		"a daemon that has never reported a heartbeat must stay nil, not become 0")
+}
+
+func TestReflectDaemonHealthMetrics(t *testing.T) {
+	ts := daemonHealthServer(t, daemonHealthBody)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+	require.NoError(t, CollectDaemonHealth(t.Context(), c))
+
+	ch := make(chan prometheus.Metric, 16)
+	go func() {
+		reflectDaemonHealth(c, ch)
+		close(ch)
+	}()
+
+	healthy := make(map[string]float64)
+	heartbeats := make(map[string]float64)
+	required := make(map[string]string)
+	for m := range ch {
+		var dm dto.Metric
+		require.NoError(t, m.Write(&dm))
+		labels := make(map[string]string)
+		for _, l := range dm.GetLabel() {
+			labels[l.GetName()] = l.GetValue()
+		}
+		if _, ok := labels["required"]; ok {
+			healthy[labels["daemon_type"]] = dm.GetGauge().GetValue()
+			required[labels["daemon_type"]] = labels["required"]
+		} else {
+			heartbeats[labels["daemon_type"]] = dm.GetGauge().GetValue()
+		}
+	}
+
+	assert.Equal(t, float64(1), healthy["SCHEDULER"])
+	assert.Equal(t, float64(0), healthy["SENSOR"])
+	assert.Equal(t, float64(0), healthy["BACKFILL"])
+	assert.Equal(t, "true", required["SCHEDULER"])
+	assert.Equal(t, "false", required["BACKFILL"])
+
+	assert.Len(t, heartbeats, 2, "the daemon with no heartbeat should produce no timestamp series at all")
+	assert.NotContains(t, heartbeats, "BACKFILL")
+	assert.InDelta(t, 1786766271.6, heartbeats["SCHEDULER"], 1e-6)
+}
+
+func TestCollectDaemonHealthReturnsErrorOnServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+	assert.Error(t, CollectDaemonHealth(t.Context(), c))
+}

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -381,6 +381,50 @@ func getWorkspaceStatus(ctx context.Context, request *GraphQLRequest, dagsterGra
 	return &resp, nil
 }
 
+// GraphQLDaemonHealthResponse is the shape of instance.daemonHealth. Unlike
+// the roster/runs/workspace queries there is no union here — instance and
+// daemonHealth are both non-null object types — so there is no __typename to
+// check and no unexpectedUnionMember call in getDaemonHealth.
+//
+// lastHeartbeatTime is nullable: a daemon that has never reported one has no
+// timestamp rather than a zero, hence the pointer.
+type GraphQLDaemonHealthResponse struct {
+	Data struct {
+		Instance struct {
+			DaemonHealth struct {
+				AllDaemonStatuses []struct {
+					DaemonType          string   `json:"daemonType"`
+					Required            bool     `json:"required"`
+					Healthy             *bool    `json:"healthy"`
+					LastHeartbeatTime   *float64 `json:"lastHeartbeatTime"`
+					LastHeartbeatErrors []struct {
+						Message string `json:"message"`
+					} `json:"lastHeartbeatErrors"`
+				} `json:"allDaemonStatuses"`
+			} `json:"daemonHealth"`
+		} `json:"instance"`
+	} `json:"data"`
+	graphQLErrors
+}
+
+//go:embed queries/get_daemon_health.graphql
+var daemonHealthQuery string
+
+func getDaemonHealthRequest() *GraphQLRequest {
+	return &GraphQLRequest{
+		Query: daemonHealthQuery,
+	}
+}
+
+func getDaemonHealth(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLDaemonHealthResponse, error) {
+	var resp GraphQLDaemonHealthResponse
+	if err := doGraphQL(ctx, request, dagsterGraphQLEndpoint, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 //go:embed queries/get_version.graphql
 var versionQuery string
 

--- a/internal/collector/queries/get_daemon_health.graphql
+++ b/internal/collector/queries/get_daemon_health.graphql
@@ -1,0 +1,15 @@
+query GetDaemonHealth {
+  instance {
+    daemonHealth {
+      allDaemonStatuses {
+        daemonType
+        required
+        healthy
+        lastHeartbeatTime
+        lastHeartbeatErrors {
+          message
+        }
+      }
+    }
+  }
+}

--- a/internal/server/scrape.go
+++ b/internal/server/scrape.go
@@ -29,6 +29,7 @@ func scrapeDagster(ctx context.Context, c *collector.DagsterCollector) {
 	spawn("active_runs", collector.CollectActiveRuns)
 	spawn("completed_runs", collector.CollectCompletedRuns)
 	spawn("code_location_status", collector.CollectCodeLocationStatus)
+	spawn("daemon_health", collector.CollectDaemonHealth)
 
 	wg.Wait()
 }


### PR DESCRIPTION
## What

A fifth collector, querying `instance.daemonHealth`, and two metrics:

| Metric | Labels |
|---|---|
| `dagster_daemon_healthy` | `daemon_type`, `required` |
| `dagster_daemon_last_heartbeat_timestamp_seconds` | `daemon_type` |

Plus `Daemon Health` and `Daemon Heartbeat Age` panels on the dashboard, and the docs.

## Why

Every other metric in this exporter describes Dagster's *work* — runs, schedules, sensors, code locations — and all of it is served by the webserver. The webserver is a different process from the daemon and stays perfectly healthy when the daemon dies.

So when the `SCHEDULER` daemon stops, nothing in `/metrics` changes:

| Metric | With the daemon dead |
|---|---|
| `dagster_schedule_status{status="running"}` | still `1` — the schedule *is* enabled; this reports on/off state, not the daemon |
| `dagster_schedule_last_tick_status` | frozen at the last tick before it died |
| `dagster_active_runs` | just goes quiet |
| `dagster_exporter_last_scrape_success` | still `1` — GraphQL is served by the webserver, which is fine |

"The scheduler is dead" and "nothing was scheduled" were indistinguishable.

This deliberately doesn't infer liveness from schedule/sensor tick recency (#84 covers that, for a different question). Tick recency says nothing in a deployment that launches everything manually or via the API, and daemon liveness shouldn't depend on whether the user happens to have defined a sensor.

`instance.daemonHealth` is a top-level field, not reachable from `repositoriesOrError`, so it gets its own query and its own collector — the same reasoning as `CollectCodeLocationStatus`.

## Why two metrics, and which one to alert on

`healthy` is **not a live check**. It is Dagster comparing the last heartbeat against a fixed tolerance:

```python
DEFAULT_DAEMON_HEARTBEAT_TOLERANCE_SECONDS = 1800   # 30 minutes
DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30             # heartbeats written every 30s
```

Verified by freezing the daemon process with `SIGSTOP` — which leaves the webserver answering, unlike `kill`, since `dagster dev` supervises both. After 14 minutes down:

```
dagster_daemon_healthy{daemon_type="SCHEDULER",required="true"} 1
time() - dagster_daemon_last_heartbeat_timestamp_seconds  ->  825    (and climbing)
```

For an every-minute schedule, that tolerance is roughly thirty missed runs before anything fires. Exporting the raw heartbeat timestamp puts the threshold in the operator's hands:

```promql
time() - dagster_daemon_last_heartbeat_timestamp_seconds{daemon_type="SCHEDULER"} > 120
```

The docs say plainly that this is the one to alert on, with `healthy` as supporting context rather than the signal. Exporting an *age* instead of a timestamp wouldn't work: it would be computed once per scrape and served unchanged, understating the outage by up to a full scrape interval.

## Nullable fields

- A null `healthy` reports **0**, not 1. The metric exists to catch a daemon that isn't answering, and no answer is not an answer.
- A daemon that has never sent a heartbeat produces **no timestamp series at all**, rather than one claiming a heartbeat at the Unix epoch — which would make every staleness alert fire on a freshly started instance.
- `lastHeartbeatErrors` is logged, not labeled, the same treatment `dagster_code_location_load_error` gives its message.

## QA

Followed the `verify-metric` workflow end to end against the dev stack (Dagster 1.13.15).

Healthy instance — all six daemons, matching what `instance.daemonHealth` returns live:

```
dagster_daemon_healthy{daemon_type="ASSET",required="true"} 1
dagster_daemon_healthy{daemon_type="BACKFILL",required="true"} 1
dagster_daemon_healthy{daemon_type="FRESHNESS_DAEMON",required="true"} 1
dagster_daemon_healthy{daemon_type="QUEUED_RUN_COORDINATOR",required="true"} 1
dagster_daemon_healthy{daemon_type="SCHEDULER",required="true"} 1
dagster_daemon_healthy{daemon_type="SENSOR",required="true"} 1
```

Daemon frozen with `SIGSTOP`, webserver still serving GraphQL — heartbeat ages climbed while `healthy` stayed 1 (quoted above). Resumed with `SIGCONT` and all six returned to fresh heartbeats:

```
ASSET: 46s   BACKFILL: 55s   FRESHNESS_DAEMON: 47s
QUEUED_RUN_COORDINATOR: 46s   SCHEDULER: 20s   SENSOR: 21s
```

Also confirmed the data path: the exporter never talks to the daemon. Heartbeats are written by the daemon into instance storage (`daemon_heartbeats` in `runs.db` on the dev stack), read by the webserver, and served over GraphQL — which is exactly why the webserver keeps answering while the daemon is down.

Unit tests cover the parsing and reflection, including both nullable cases. `go build` / `go vet` / `gofmt` / `go test -race` / `golangci-lint` clean, dashboard JSON still `jq`-formatted.

## Ref

Closes #83.