### PR TITLE
Expose the last tick timestamp for schedules and sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ Full label reference, edge cases, and design rationale for every metric below: [
 | `dagster_run_queue_concurrency_key_backlog` | Gauge | Runs queued behind a tag-based run-queue concurrency limit, per `dagster/concurrency_key` value. |
 | `dagster_schedule_status` | Gauge | Whether a schedule is currently on or off. |
 | `dagster_schedule_last_tick_status` | Gauge | Outcome of a schedule's most recent tick. |
+| `dagster_schedule_last_tick_timestamp_seconds` | Gauge | When a schedule last ticked, so a stalled schedule is detectable. |
 | `dagster_sensor_status` | Gauge | Whether a sensor is currently on or off. |
 | `dagster_sensor_last_tick_status` | Gauge | Outcome of a sensor's most recent tick. |
+| `dagster_sensor_last_tick_timestamp_seconds` | Gauge | When a sensor last ticked, so a stalled evaluation loop is detectable. |
 
 ### Exporter self-health
 

--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -732,6 +732,52 @@
         "x": 12,
         "y": 53
       }
+    },
+    {
+      "title": "Schedule Tick Age",
+      "description": "Seconds since each schedule last ticked. A schedule that stopped firing climbs without limit; note the normal range depends on the schedule's cron cadence, so there is no single alert threshold.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "time() - dagster_schedule_last_tick_timestamp_seconds",
+          "legendFormat": "{{schedule_name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      }
+    },
+    {
+      "title": "Sensor Tick Age",
+      "description": "Seconds since each sensor last ticked. Sensors tick on a fixed evaluation interval regardless of whether they launch anything, so unlike schedules this has a single meaningful threshold.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "time() - dagster_sensor_last_tick_timestamp_seconds",
+          "legendFormat": "{{sensor_name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      }
     }
   ],
   "templating": {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -111,6 +111,18 @@ Labels: `schedule_name`, `location`, `status`
 
 Always `1`; status of a schedule's most recently observed tick (`started`, `skipped`, `success`, or `failure`). A schedule that has never ticked yet has no series — no seeded value, same rationale as `dagster_last_run_info` for a job that's never run.
 
+Note this reports *what* the last tick was, not *when*. On its own it can't tell a schedule that is still ticking from one that stopped: the series simply freezes at the last outcome observed. Use `dagster_schedule_last_tick_timestamp_seconds` below for that.
+
+## `dagster_schedule_last_tick_timestamp_seconds` (Gauge)
+
+Labels: `schedule_name`, `location`
+
+Unix timestamp of the schedule's most recent tick. Exported as a timestamp rather than an age so staleness is computed at query time — `time() - dagster_schedule_last_tick_timestamp_seconds` — instead of being frozen at scrape time. Same "no series until the first tick" behavior as the status metric above, and no `status` label, since here the value carries the information and a status label would churn the series on every outcome change.
+
+There is deliberately no single recommended alert threshold. A tick is one evaluation by the daemon, and schedules tick on their cron boundary, so "no tick for an hour" is routine for a daily schedule and alarming for an every-minute one. The threshold has to come from the schedule's own cadence.
+
+This is also not the metric for "is the scheduler daemon alive" — see `dagster_daemon_healthy`, which answers that even in a deployment with no schedules or sensors defined at all. What this one adds is the per-schedule view: a single schedule that stopped firing while the daemon is perfectly healthy (silently turned off, erroring on evaluation, or a cron that never matches).
+
 ## `dagster_sensor_status` (Gauge)
 
 Labels: `sensor_name`, `location`, `status`
@@ -122,6 +134,16 @@ Same as `dagster_schedule_status`, for sensors: `running`/`stopped`.
 Labels: `sensor_name`, `location`, `status`
 
 Same as `dagster_schedule_last_tick_status`, for sensors. Note a sensor tick that decides not to launch anything is `skipped`, not a lack of data — Dagster's sensor daemon evaluates on a fixed interval regardless of whether there's anything to do, so `skipped` is a normal, common outcome, not necessarily a problem.
+
+## `dagster_sensor_last_tick_timestamp_seconds` (Gauge)
+
+Labels: `sensor_name`, `location`
+
+Same as `dagster_schedule_last_tick_timestamp_seconds`, for sensors — and the more useful of the two for spotting a stalled evaluation loop. Because sensors tick on a fixed interval (`minimum_interval_seconds`) whether or not they launch anything, staleness here has a single meaningful threshold, unlike the cron-driven schedule case:
+
+```promql
+time() - dagster_sensor_last_tick_timestamp_seconds > 300
+```
 
 ## Exporter self-health
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -24,8 +24,10 @@ type DagsterCollector struct {
 	concurrencyKeyBacklogDesc *prometheus.Desc
 	scheduleStatusDesc        *prometheus.Desc
 	scheduleTickStatusDesc    *prometheus.Desc
+	scheduleTickTimestampDesc *prometheus.Desc
 	sensorStatusDesc          *prometheus.Desc
 	sensorTickStatusDesc      *prometheus.Desc
+	sensorTickTimestampDesc   *prometheus.Desc
 	daemonHealthyDesc         *prometheus.Desc
 	daemonLastHeartbeatDesc   *prometheus.Desc
 
@@ -151,6 +153,12 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"schedule_name", "location", "status"},
 			nil,
 		),
+		scheduleTickTimestampDesc: prometheus.NewDesc(
+			"dagster_schedule_last_tick_timestamp_seconds",
+			"Unix timestamp of a schedule's most recent tick. Exported as a timestamp rather than an age so staleness is computed at query time (time() - metric), not frozen at scrape time",
+			[]string{"schedule_name", "location"},
+			nil,
+		),
 		sensorStatusDesc: prometheus.NewDesc(
 			"dagster_sensor_status",
 			"Whether a sensor is currently turned on (value is always 1; status is carried in the status label, one of running/stopped)",
@@ -161,6 +169,12 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			"dagster_sensor_last_tick_status",
 			"Status of a sensor's most recent tick (value is always 1; status is carried in the status label, one of started/skipped/success/failure)",
 			[]string{"sensor_name", "location", "status"},
+			nil,
+		),
+		sensorTickTimestampDesc: prometheus.NewDesc(
+			"dagster_sensor_last_tick_timestamp_seconds",
+			"Unix timestamp of a sensor's most recent tick. Exported as a timestamp rather than an age so staleness is computed at query time (time() - metric), not frozen at scrape time",
+			[]string{"sensor_name", "location"},
 			nil,
 		),
 		daemonHealthyDesc: prometheus.NewDesc(
@@ -196,8 +210,10 @@ func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.concurrencyKeyBacklogDesc
 	ch <- c.scheduleStatusDesc
 	ch <- c.scheduleTickStatusDesc
+	ch <- c.scheduleTickTimestampDesc
 	ch <- c.sensorStatusDesc
 	ch <- c.sensorTickStatusDesc
+	ch <- c.sensorTickTimestampDesc
 	ch <- c.daemonHealthyDesc
 	ch <- c.daemonLastHeartbeatDesc
 	c.completedRunsCounter.Describe(ch)

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -23,10 +23,11 @@ func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
 	// activeRunsDesc, lastRunStatusDesc, scrapeDurationDesc, lastScrapeSuccessDesc,
 	// codeLocationLoadErrorDesc, lastRunDurationDesc, activeRunDurationDesc,
 	// concurrencyKeyBacklogDesc, scheduleStatusDesc, scheduleTickStatusDesc,
-	// sensorStatusDesc, sensorTickStatusDesc, daemonHealthyDesc,
-	// daemonLastHeartbeatDesc, plus one each from completedRunsCounter and
+	// scheduleTickTimestampDesc, sensorStatusDesc, sensorTickStatusDesc,
+	// sensorTickTimestampDesc, daemonHealthyDesc, daemonLastHeartbeatDesc,
+	// plus one each from completedRunsCounter and
 	// scrapeErrorsCounter.
-	assert.Equal(t, 16, descCount)
+	assert.Equal(t, 18, descCount)
 
 	c.RecordScrapeResult("active_runs", 10*time.Millisecond, nil)
 

--- a/internal/collector/definitions_roster_test.go
+++ b/internal/collector/definitions_roster_test.go
@@ -194,18 +194,42 @@ func TestCollectDefinitionsRosterTracksScheduleStatusAndLastTick(t *testing.T) {
 	for m := range tickCh {
 		tickMetrics = append(tickMetrics, m)
 	}
-	require.Len(t, tickMetrics, 1, "only the schedule that has ticked should produce a series")
+	// Two series per ticked schedule: the status, and the timestamp that makes
+	// "this schedule stopped ticking" detectable.
+	require.Len(t, tickMetrics, 2, "the schedule that has ticked should produce a status and a timestamp series")
 
-	var dm dto.Metric
-	require.NoError(t, tickMetrics[0].Write(&dm))
-	assert.Equal(t, float64(1), dm.GetGauge().GetValue())
+	var status, timestamp *dto.Metric
+	for _, m := range tickMetrics {
+		var dm dto.Metric
+		require.NoError(t, m.Write(&dm))
+		if strings.Contains(m.Desc().String(), "dagster_schedule_last_tick_timestamp_seconds") {
+			timestamp = &dm
+		} else {
+			status = &dm
+		}
+	}
+	require.NotNil(t, status)
+	require.NotNil(t, timestamp)
+
+	assert.Equal(t, float64(1), status.GetGauge().GetValue())
 	labels := make(map[string]string)
-	for _, l := range dm.GetLabel() {
+	for _, l := range status.GetLabel() {
 		labels[l.GetName()] = l.GetValue()
 	}
 	assert.Equal(t, "my_schedule", labels["schedule_name"])
 	assert.Equal(t, "loc_a", labels["location"])
 	assert.Equal(t, "success", labels["status"])
+
+	// The newest tick is SUCCESS@200; the older FAILURE@100 must not win.
+	assert.Equal(t, float64(200), timestamp.GetGauge().GetValue())
+	tsLabels := make(map[string]string)
+	for _, l := range timestamp.GetLabel() {
+		tsLabels[l.GetName()] = l.GetValue()
+	}
+	assert.Equal(t, "my_schedule", tsLabels["schedule_name"])
+	assert.Equal(t, "loc_a", tsLabels["location"])
+	assert.NotContains(t, tsLabels, "status",
+		"the timestamp carries the information in its value; a status label would churn the series")
 }
 
 // Dagster's InstigationState.ticks returns an empty list when asked with a

--- a/internal/collector/schedules.go
+++ b/internal/collector/schedules.go
@@ -11,11 +11,13 @@ type ScheduleKey struct {
 	LocationName string
 }
 
-// scheduleTickEntry tracks the status of a schedule's most recently
-// observed tick, for dagster_schedule_last_tick_status. timestamp isn't
-// currently exposed as a metric itself, but is kept alongside status since
-// it's what "most recent" is determined by (ticks(limit: 1, afterTimestamp: 1) already returns
-// newest-first, so this is mostly for future use/debugging).
+// scheduleTickEntry tracks a schedule's most recently observed tick, for
+// dagster_schedule_last_tick_status and
+// dagster_schedule_last_tick_timestamp_seconds. ticks(limit: 1,
+// afterTimestamp: 1) already returns newest-first, so timestamp is not used
+// to pick the entry — it is reported as its own metric, because the status
+// alone can't distinguish a schedule that is still ticking from one that
+// stopped.
 type scheduleTickEntry struct {
 	status    string
 	timestamp float64
@@ -69,9 +71,15 @@ func reflectScheduleStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
 	}
 }
 
-// reflectScheduleTickStatus emits dagster_schedule_last_tick_status for
-// every schedule that has ticked at least once. Same "no seeded value
-// until the first observation" behavior as dagster_last_run_info.
+// reflectScheduleTickStatus emits dagster_schedule_last_tick_status and
+// dagster_schedule_last_tick_timestamp_seconds for every schedule that has
+// ticked at least once. Same "no seeded value until the first observation"
+// behavior as dagster_last_run_info, and the same single-pass reasoning as
+// reflectLastRun: both come from one entry.
+//
+// The timestamp is what makes "this schedule stopped ticking" detectable at
+// all. The status metric alone stays frozen at the last observed outcome, so
+// a schedule that quietly stops firing keeps reporting success forever.
 func reflectScheduleTickStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -83,6 +91,13 @@ func reflectScheduleTickStatus(c *DagsterCollector, ch chan<- prometheus.Metric)
 			key.ScheduleName,
 			key.LocationName,
 			strings.ToLower(entry.status),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.scheduleTickTimestampDesc,
+			prometheus.GaugeValue,
+			entry.timestamp,
+			key.ScheduleName,
+			key.LocationName,
 		)
 	}
 }

--- a/internal/collector/sensors.go
+++ b/internal/collector/sensors.go
@@ -66,9 +66,11 @@ func reflectSensorStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
 	}
 }
 
-// reflectSensorTickStatus emits dagster_sensor_last_tick_status for every
-// sensor that has ticked at least once. Same "no seeded value until the
-// first observation" behavior as dagster_last_run_info.
+// reflectSensorTickStatus emits dagster_sensor_last_tick_status and
+// dagster_sensor_last_tick_timestamp_seconds, mirroring
+// reflectScheduleTickStatus. Sensors tick on a fixed evaluation interval
+// rather than a cron boundary, so their timestamp is the cleaner liveness
+// signal of the two — see docs/metrics.md.
 func reflectSensorTickStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -80,6 +82,13 @@ func reflectSensorTickStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
 			key.SensorName,
 			key.LocationName,
 			strings.ToLower(entry.status),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.sensorTickTimestampDesc,
+			prometheus.GaugeValue,
+			entry.timestamp,
+			key.SensorName,
+			key.LocationName,
 		)
 	}
 }


### PR DESCRIPTION
## What

Two metrics, plus the panels for them:

| Metric | Labels |
|---|---|
| `dagster_schedule_last_tick_timestamp_seconds` | `schedule_name`, `location` |
| `dagster_sensor_last_tick_timestamp_seconds` | `sensor_name`, `location` |

## Why

`dagster_schedule_last_tick_status` reports *what* the last tick was, never *when*. So a schedule that quietly stops firing keeps reporting `success` forever, and nothing else in `/metrics` gives it away either:

| Metric | When a schedule stops ticking |
|---|---|
| `dagster_schedule_last_tick_status{status="success"}` | frozen at the last tick before it stopped |
| `dagster_schedule_status{status="running"}` | still `1` — reports the on/off state, not whether anything is happening |
| `dagster_active_runs` | just goes quiet |

The data was already being collected. `buildScheduleState` and `buildSensorState` read the tick timestamp into `scheduleTickEntry`/`sensorTickEntry`, with a comment saying it went nowhere. This exports it.

## Design notes

**Timestamps, not ages.** Staleness gets computed at query time (`time() - metric`) rather than frozen at scrape time — an exported age would understate an outage by up to a full scrape interval.

**No `status` label.** Unlike the `_status` metrics, the value carries the information here, and a status label would churn the series every time the outcome changed.

**Not a substitute for `dagster_daemon_healthy`.** Tick recency says nothing in a deployment with no schedules or sensors defined, which is why daemon liveness has its own metric (#83). What this adds is the per-schedule view: one schedule that stopped while the daemon is perfectly healthy — silently turned off, erroring on evaluation, or a cron that never matches.

**No recommended threshold for schedules.** They tick on their cron boundary, so an hour without a tick is routine for a daily schedule and alarming for an every-minute one; the docs say so instead of implying a single rule. Sensors tick on a fixed interval regardless of whether they launch anything, so those do get one:

```promql
time() - dagster_sensor_last_tick_timestamp_seconds > 300
```

## QA

Followed the `verify-metric` workflow. Both series present against the dev stack:

```
dagster_schedule_last_tick_timestamp_seconds{schedule_name="quick_job_schedule"} 1.78678362e+09
dagster_sensor_last_tick_timestamp_seconds{sensor_name="quick_job_sensor"}       1.786783639e+09
dagster_sensor_last_tick_timestamp_seconds{sensor_name="failing_sensor"}         1.786783638e+09
```

Panel sweep — the two new panels render, and nothing else regressed:

```
ok  Daemon Health                        6 series
ok  Daemon Heartbeat Age                 6 series
ok  Schedule Tick Age                    1 series
ok  Sensor Tick Age                      2 series
```

`go build` / `go vet` / `gofmt` / `go test -race` / `golangci-lint` clean, dashboard JSON still `jq`-formatted.

Worth noting these metrics would have been dead on arrival before #87 — the roster query returned no ticks at all, so there was no timestamp to export.

## Ref

Closes #84.