### PR TITLE
Bump the chart to 0.1.4 and its appVersion to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Or deploy to Kubernetes with the [Helm chart](charts/dagster-prometheus-exporter
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.3 \
+  --version 0.1.4 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 

--- a/charts/dagster-prometheus-exporter/Chart.yaml
+++ b/charts/dagster-prometheus-exporter/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: dagster-prometheus-exporter
 description: A Prometheus exporter for Dagster run metrics
 type: application
-version: 0.1.3
+version: 0.1.4
 # Must exactly match a real tag on ghcr.io/hirofumitsuda/dagster-prometheus-exporter
 # (no "v" prefix — docker/metadata-action's {{version}} pattern in
 # docker-publish.yml strips it from the git tag when publishing), since
 # templates/deployment.yaml defaults image.tag to this value.
-appVersion: "0.2.0"
+appVersion: "0.3.0"
 home: https://github.com/HirofumiTsuda/dagster-prometheus-exporter
 sources:
   - https://github.com/HirofumiTsuda/dagster-prometheus-exporter

--- a/charts/dagster-prometheus-exporter/README.md
+++ b/charts/dagster-prometheus-exporter/README.md
@@ -8,7 +8,7 @@ The chart is published as an OCI artifact to GHCR:
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.3 \
+  --version 0.1.4 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 


### PR DESCRIPTION
## What

Chart `0.1.3` → `0.1.4`, `appVersion` `"0.2.0"` → `"0.3.0"`, and the `--version` in both install snippets.

## Why

Points the chart's default image at the [v0.3.0](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/releases/tag/v0.3.0) release — four new metrics, three fixes, and one breaking label change.

Worth recording the **ordering this now requires**, since it's the reverse of how v0.2.0 was released. `helm-lint.yml` verifies that the image the chart renders by default actually exists on GHCR — the regression check added after the `appVersion`/published-tag mismatch that shipped in `chart-v0.1.0`–`0.1.2`. So the app tag has to be pushed and its image published *before* this bump can pass CI. Doing it the old way (chart first) would now fail, correctly.

## QA

Ran the same check `helm-lint.yml` runs, locally, against the already-published image:

```
rendered: ghcr.io/hirofumitsuda/dagster-prometheus-exporter:0.3.0
GHCR manifest -> HTTP 200
```

`helm lint --strict` passes (helm 4.2.4, from `.tool-versions`).

The published image was verified independently before tagging the chart — pulled anonymously, run, and its build info matched the release commit:

```
dagster_exporter_build_info{commit="79161ea2b3456ae0713a5ac80163bfa4ce686376",version="v0.3.0"} 1
```

## Ref

Follows the v0.3.0 app release. `chart-v0.1.4` will be tagged once this merges.