### PR TITLE
Ask bug reports for the chart version and the exporter's own build info

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,22 @@ What happened, and what did you expect instead?
 - Exporter version / image tag:
 - Dagster version:
 - Deployment (Docker / Kubernetes / binary):
+- Helm chart version, if installed via Helm:
+
+The exporter reports its own version and commit, which is more precise than the
+image tag if you are running `latest`:
+
+```sh
+curl -s localhost:9101/metrics | grep dagster_exporter_build_info
+```
 
 ## Logs / metrics output
 
 Relevant log output, or the `/metrics` output for the affected series.
+
+If a metric is missing or empty rather than wrong, the exporter's self-health
+series are usually the fastest way to narrow it down:
+
+```sh
+curl -s localhost:9101/metrics | grep dagster_exporter_
+```


### PR DESCRIPTION
## What

Extend the `Environment` and `Logs / metrics output` sections of the bug report
issue template:

- Add a `Helm chart version, if installed via Helm:` field.
- Point reporters at `dagster_exporter_build_info` for the exact version and
  commit of the running binary.
- Point reporters at the `dagster_exporter_` self-health series when a metric is
  missing or empty rather than wrong.

No change to `feature_request.md`, and no `config.yml` — blank issues stay
enabled.

## Why

The template asked for one version, but this project ships two that move
independently. The chart and the app have separate tag series (`chart-v0.1.4`
currently renders appVersion `0.3.0`), and #64 was a bug that existed purely in
the gap between them: the chart's default `image.tag` pointed at a tag that was
never published. A report that names only one of the two can't reproduce that
class of problem.

`Exporter version / image tag` also degrades badly for anyone running `latest`,
which is what the README's quickest path gives them. `dagster_exporter_build_info`
carries both version and commit as labels, so it identifies the build exactly
and doesn't depend on the reporter remembering which tag they pulled.

The self-health pointer is aimed at the failure mode this exporter actually
produces. #85 was a metric that had never emitted a value since being added —
the Grafana panel existed and was simply empty, and nothing in `/metrics` said
anything was wrong. An empty series and a broken scrape look identical from the
outside, and `dagster_exporter_last_scrape_success` /
`dagster_exporter_scrape_errors_total` are what separate them. Asking for that
up front should save a round trip on the reports most likely to arrive.

## QA

Documentation only — no code, no chart, no CI changes.

- Confirmed the YAML front matter is untouched, so the template keeps its
  `Bug report` name and `bug` label.
- Confirmed `9101` is the default `PORT` in `internal/config/config.go`, so the
  suggested `curl` commands work against a default deployment.
- Confirmed `dagster_exporter_build_info` is registered with `version` and
  `commit` labels in `internal/server/build_info.go`.

## Ref

Follow-up to #27, which added the templates. Motivated by #64 (chart/app version
skew) and #85 (metric silently empty).