### PR TITLE
Add asset materialization metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/HirofumiTsuda/dagster-prometheus-exporter.svg)](https://pkg.go.dev/github.com/HirofumiTsuda/dagster-prometheus-exporter)
 [![License: MIT](https://img.shields.io/github/license/HirofumiTsuda/dagster-prometheus-exporter)](LICENSE)
 
-A Prometheus exporter for [Dagster](https://dagster.io/). It polls Dagster's GraphQL API on an interval and exposes run counts, statuses and durations, schedule and sensor state, run-queue backlog, and code-location load errors as Prometheus metrics.
+A Prometheus exporter for [Dagster](https://dagster.io/). It polls Dagster's GraphQL API on an interval and exposes run counts, statuses and durations, schedule and sensor state, asset staleness and materialization status, run-queue backlog, and code-location load errors as Prometheus metrics.
 
 ![Dagster Run Monitoring dashboard in Grafana](docs/images/grafana-dashboard.png)
 
@@ -66,14 +66,14 @@ flowchart LR
     Prometheus["Prometheus"]
     Grafana["Grafana"]
 
-    Exporter -- "poll every N seconds<br/>(runsOrError, repositoriesOrError,<br/>workspaceOrError)" --> Dagster
+    Exporter -- "poll every N seconds<br/>(runsOrError, repositoriesOrError,<br/>workspaceOrError, assetNodes)" --> Dagster
     Prometheus -- "scrape /metrics" --> Exporter
     Grafana -- query --> Prometheus
 ```
 
-A single Go binary with no external state store: it polls Dagster's GraphQL API on an interval, keeps the result in memory, and serves it from `/metrics`. Scraping (writing that state) and serving `/metrics` (reading it) are decoupled, so a slow or failing Dagster GraphQL call never blocks or breaks a `/metrics` request — it just serves the last known state. Five collectors (definitions roster, active runs, completed runs, code-location load status, daemon health) run concurrently on every scrape.
+A single Go binary with no external state store: it polls Dagster's GraphQL API on an interval, keeps the result in memory, and serves it from `/metrics`. Scraping (writing that state) and serving `/metrics` (reading it) are decoupled, so a slow or failing Dagster GraphQL call never blocks or breaks a `/metrics` request — it just serves the last known state. Six collectors (definitions roster, active runs, completed runs, code-location load status, daemon health, asset status) run concurrently on every scrape.
 
-For the package layout, why there are four separate collectors, and how completed-run fetching stays incremental instead of re-scanning everything every cycle, see [docs/architecture.md](docs/architecture.md).
+For the package layout, why there are six separate collectors, and how completed-run fetching stays incremental instead of re-scanning everything every cycle, see [docs/architecture.md](docs/architecture.md).
 
 ## Metrics
 
@@ -98,10 +98,12 @@ Full label reference, edge cases, and design rationale for every metric below: [
 | `dagster_sensor_status` | Gauge | Whether a sensor is currently on or off. |
 | `dagster_sensor_last_tick_status` | Gauge | Outcome of a sensor's most recent tick. |
 | `dagster_sensor_last_tick_timestamp_seconds` | Gauge | When a sensor last ticked, so a stalled evaluation loop is detectable. |
+| `dagster_asset_stale_status` | Gauge | Whether an asset's data is missing, stale, or fresh. |
+| `dagster_asset_last_materialization_status` | Gauge | Outcome of an asset's most recently launched materializing run — the only one of the two that shows a failed run, since staleness alone can't tell "failed" from "never run". |
 
 ### Exporter self-health
 
-These report on the exporter itself rather than on Dagster's run state. The first three are labeled `collector` (one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status` — see [docs/architecture.md](docs/architecture.md)).
+These report on the exporter itself rather than on Dagster's run state. The first three are labeled `collector` (one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status`, `daemon_health`, `asset_status` — see [docs/architecture.md](docs/architecture.md)).
 
 | Metric | Type | Description |
 | --- | --- | --- |
@@ -139,6 +141,12 @@ dagster_schedule_last_tick_status{schedule_name="daily_refresh",location="dev-da
 dagster_sensor_status{sensor_name="new_file_sensor",location="dev-dagster-workspace",status="running"} 1
 
 dagster_sensor_last_tick_status{sensor_name="new_file_sensor",location="dev-dagster-workspace",status="skipped"} 1
+
+dagster_asset_stale_status{asset_key="good_asset",status="fresh"} 1
+dagster_asset_stale_status{asset_key="bad_asset",status="missing"} 1
+
+dagster_asset_last_materialization_status{asset_key="good_asset",status="success"} 1
+dagster_asset_last_materialization_status{asset_key="bad_asset",status="failure"} 1
 ```
 
 ### PromQL examples
@@ -182,6 +190,12 @@ dagster_schedule_last_tick_status{status!="success"} == 1
 dagster_sensor_status{status="running"} == 1
 and on (sensor_name, location)
 dagster_sensor_last_tick_status{status="failure"} == 1
+
+# Assets whose most recent materializing run failed
+# (dagster_asset_stale_status alone can't show this: it's derived from
+# assetMaterializations, which only records successful events, so a failing
+# asset looks the same as one that has simply never run)
+dagster_asset_last_materialization_status{status="failure"}
 ```
 
 ## Endpoints
@@ -363,7 +377,7 @@ CI (`.github/workflows/ci.yml`) runs all of the above — Go steps only when `.g
 - [x] Run queue concurrency-key backlog
 - [x] Schedule tick status
 - [x] Sensor tick status
-- [ ] Asset materialization metrics — several open design questions (metric shape, `asset_key` label encoding, collector structure); see [#56](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/56)
+- [x] Asset materialization metrics ([#56](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/56))
 - [x] Published container image / tagged release
 - [x] Helm chart for Kubernetes deployment
 

--- a/dev/dagster_workspace/definitions.py
+++ b/dev/dagster_workspace/definitions.py
@@ -1,5 +1,5 @@
 from dagster import Definitions
 
-from dev.dagster_workspace.job import jobs, schedules, sensors
+from dev.dagster_workspace.job import assets, jobs, schedules, sensors
 
-defs = Definitions(jobs=jobs, schedules=schedules, sensors=sensors)
+defs = Definitions(jobs=jobs, schedules=schedules, sensors=sensors, assets=assets)

--- a/dev/dagster_workspace/job.py
+++ b/dev/dagster_workspace/job.py
@@ -6,6 +6,7 @@ from dagster import (
     ScheduleDefinition,
     SensorEvaluationContext,
     SkipReason,
+    asset,
     job,
     op,
     sensor,
@@ -87,3 +88,27 @@ def failing_sensor(context: SensorEvaluationContext):
 
 
 sensors = [quick_job_sensor, failing_sensor]
+
+
+@asset
+def good_asset():
+    """An asset that materializes successfully every time, for exercising
+    dagster_asset_last_materialization_status{status="success"} and
+    dagster_asset_stale_status."""
+    return 1
+
+
+@asset
+def bad_asset():
+    """An asset that always fails to materialize, for exercising
+    dagster_asset_last_materialization_status{status="failure"} — the same
+    reasoning as failing_job/failing_sensor: assetsLatestInfo.latestRun is
+    the only source for this, since assetMaterializations only ever records
+    successful events (see issue #56's investigation notes)."""
+    raise RuntimeError(
+        "dev fixture: intentionally always fails, for exercising "
+        "dagster_asset_last_materialization_status{status=\"failure\"}"
+    )
+
+
+assets = [good_asset, bad_asset]

--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -778,6 +778,166 @@
         "x": 12,
         "y": 61
       }
+    },
+    {
+      "title": "Asset Stale Status",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "dagster_asset_stale_status",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "fresh": {
+                        "text": "Fresh",
+                        "color": "green"
+                      },
+                      "stale": {
+                        "text": "Stale",
+                        "color": "yellow"
+                      },
+                      "missing": {
+                        "text": "Missing",
+                        "color": "red"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      }
+    },
+    {
+      "title": "Asset Last Materialization Status",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "dagster_asset_last_materialization_status",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "success": {
+                        "text": "Success",
+                        "color": "green"
+                      },
+                      "failure": {
+                        "text": "Failure",
+                        "color": "red"
+                      },
+                      "started": {
+                        "text": "Started",
+                        "color": "yellow"
+                      },
+                      "starting": {
+                        "text": "Starting",
+                        "color": "yellow"
+                      },
+                      "queued": {
+                        "text": "Queued",
+                        "color": "light-blue"
+                      },
+                      "canceled": {
+                        "text": "Canceled",
+                        "color": "light-grey"
+                      },
+                      "canceling": {
+                        "text": "Canceling",
+                        "color": "light-grey"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      }
     }
   ],
   "templating": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,17 +9,19 @@ The exporter is a single Go binary with no external state store — everything i
 - `cmd/exporter` — entrypoint; loads config and starts the server.
 - `internal/config` — reads settings from environment variables.
 - `internal/server` — runs the HTTP server (`/metrics`, `/healthz`, `/readyz`) and a background ticker that triggers a scrape on `DAGSTER_SCRAPING_INTERVAL_SECONDS`.
-- `internal/collector` — on each scrape, queries Dagster's GraphQL API (active runs, completed runs, the definitions roster, and each code location's load status) and updates the in-memory state behind a mutex; `DagsterCollector` implements `prometheus.Collector` and renders that state into metrics whenever Prometheus scrapes `/metrics`.
+- `internal/collector` — on each scrape, queries Dagster's GraphQL API (active runs, completed runs, the definitions roster, each code location's load status, daemon health, and asset status) and updates the in-memory state behind a mutex; `DagsterCollector` implements `prometheus.Collector` and renders that state into metrics whenever Prometheus scrapes `/metrics`.
 
 Because scraping (writing state) and metrics rendering (reading state) are decoupled, a slow or failing Dagster GraphQL call never blocks or breaks a `/metrics` request — it just serves the last known state.
 
-## Why five collectors, and why they're split the way they are
+## Why six collectors, and why they're split the way they are
 
-The five collectors (definitions roster, active runs, completed runs, code-location load status, daemon health) run concurrently on every scrape — each locks `DagsterCollector`'s own mutex only around its own critical section, so they don't block each other or `/metrics`.
+The six collectors (definitions roster, active runs, completed runs, code-location load status, daemon health, asset status) run concurrently on every scrape — each locks `DagsterCollector`'s own mutex only around its own critical section, so they don't block each other or `/metrics`.
 
 The code-location load status collector is intentionally independent of the definitions-roster one: `repositoriesOrError` (used for the roster) silently omits a code location that fails to load rather than erroring out, so a separate `workspaceOrError` query is needed to detect that failure at all — see `dagster_code_location_load_error` in the [metrics reference](metrics.md).
 
 The daemon-health collector is likewise independent: `instance.daemonHealth` is a top-level field, not something reachable from `repositoriesOrError`, so it needs its own query. It is also the only collector that reports on Dagster's *machinery* rather than its work — everything else here describes runs, schedules, sensors and code locations, all of which the webserver keeps answering perfectly while the daemon is down.
+
+The asset-status collector is a third independent one, and the only one that makes two GraphQL round trips instead of one: `assetNodes` (every asset defined, across every code location, no `repositorySelector` needed) has to run first, because `assetsLatestInfo` needs the asset keys it returns as its `assetKeys` argument. Neither field hangs off `repositoriesOrError`. See `dagster_asset_last_materialization_status` in the [metrics reference](metrics.md) for why staleness alone (`assetNodes.staleStatus`) can't tell a failed run apart from one that never happened.
 
 `dagster_run_queue_concurrency_key_backlog` is folded into the active-runs collector instead of getting its own: it only needs `QUEUED` runs' tags, which that collector already fetches on every page, so a separate query would just re-fetch the same runs a second time for no reason.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -145,9 +145,25 @@ Same as `dagster_schedule_last_tick_timestamp_seconds`, for sensors — and the 
 time() - dagster_sensor_last_tick_timestamp_seconds > 300
 ```
 
+## `dagster_asset_stale_status` (Gauge)
+
+Labels: `asset_key`, `status`
+
+Always `1`; an "info" metric reporting whether an asset's data is `missing`, `stale`, or `fresh`, from Dagster's `assetNodes.staleStatus`. `asset_key` is the asset's path segments joined with `/` (e.g. `my_dbt_project/customers`), the same separator Dagster's own UI uses. No series at all for an asset Dagster reports no computable stale status for (the field is nullable in the schema).
+
+Note this is derived from `assetMaterializations`, which only ever records successful events — a `failure`-status run in `dagster_asset_last_materialization_status` below still shows `missing`/`stale` here rather than anything reflecting the failure. Use the two metrics together, not this one alone, to tell "never materialized" apart from "materialization keeps failing".
+
+## `dagster_asset_last_materialization_status` (Gauge)
+
+Labels: `asset_key`, `status`
+
+Always `1`; status of an asset's most recently launched materializing run (`assetsLatestInfo.latestRun.status`, e.g. `success`, `failure`, `started`). No series at all for an asset that has never had a run.
+
+This exists because `dagster_asset_stale_status` can't answer "did the last run succeed": `assetMaterializations` (and the `staleStatus` derived from it) only records successful events, so a failing asset and one that has simply never run both look `missing` there. This metric reads the run itself instead, so a failed run is visible even though it left the asset's materialization history untouched.
+
 ## Exporter self-health
 
-These report on the exporter itself, rather than on Dagster's run state. The first three are about whether its own scrapes of Dagster are succeeding, and are labeled `collector`, one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status`, or `daemon_health` (the five concurrent collectors described in [docs/architecture.md](architecture.md)).
+These report on the exporter itself, rather than on Dagster's run state. The first three are about whether its own scrapes of Dagster are succeeding, and are labeled `collector`, one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status`, `daemon_health`, or `asset_status` (the six concurrent collectors described in [docs/architecture.md](architecture.md)).
 
 ### `dagster_exporter_scrape_duration_seconds` (Gauge)
 

--- a/internal/collector/asset_status.go
+++ b/internal/collector/asset_status.go
@@ -1,0 +1,125 @@
+package collector
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// assetStatusEntry is one asset's most recently observed state.
+type assetStatusEntry struct {
+	// staleStatus is "" when Dagster reports no stale status for this asset
+	// (the field is nullable in the schema) — no dagster_asset_stale_status
+	// series is emitted for it.
+	staleStatus string
+	// lastMaterializationStatus is "" when the asset has never had a run —
+	// no dagster_asset_last_materialization_status series is emitted for it.
+	lastMaterializationStatus string
+}
+
+// CollectAssetStatus reports each asset's staleness and the outcome of its
+// most recent materializing run.
+//
+// This is two GraphQL round trips rather than one: assetNodes (every asset
+// currently defined, across every code location, in one fetch — like
+// repositoriesOrError but without a repositorySelector or per-location
+// union) has to run first, because assetsLatestInfo needs the asset keys it
+// returns as input. Neither field is reachable via repositoriesOrError, so
+// this is its own collector — the same reasoning as
+// CollectCodeLocationStatus and CollectDaemonHealth.
+//
+// assetNodes.staleStatus alone can't answer "did the last run succeed":
+// staleStatus is derived from assetMaterializations, which only ever
+// records successful events. A run that fails before producing a
+// materialization leaves an asset looking exactly like one that has simply
+// never run (see issue #56's investigation notes). Only
+// assetsLatestInfo.latestRun.status distinguishes the two, hence the second
+// query.
+func CollectAssetStatus(ctx context.Context, c *DagsterCollector) error {
+	nodesReq := getAssetNodesRequest()
+	nodesResp, err := getAssetNodes(ctx, nodesReq, c.dagsterGraphQLEndpoint)
+	if err != nil {
+		log.Printf("failed to collect asset nodes from dagster: %v", err)
+		return err
+	}
+
+	entries := make(map[string]assetStatusEntry, len(nodesResp.Data.AssetNodes))
+	assetKeys := make([]AssetKeyPath, 0, len(nodesResp.Data.AssetNodes))
+	for _, node := range nodesResp.Data.AssetNodes {
+		var entry assetStatusEntry
+		if node.StaleStatus != nil {
+			entry.staleStatus = *node.StaleStatus
+		}
+		entries[assetKeyLabel(node.AssetKey.Path)] = entry
+		assetKeys = append(assetKeys, node.AssetKey.Path)
+	}
+
+	// No assets defined anywhere: skip the second query rather than ask
+	// assetsLatestInfo for an empty key list.
+	if len(assetKeys) > 0 {
+		infoReq := getAssetsLatestInfoRequest(assetKeys)
+		infoResp, err := getAssetsLatestInfo(ctx, infoReq, c.dagsterGraphQLEndpoint)
+		if err != nil {
+			log.Printf("failed to collect assets latest info from dagster: %v", err)
+			return err
+		}
+
+		for _, info := range infoResp.Data.AssetsLatestInfo {
+			if info.LatestRun == nil {
+				continue
+			}
+			key := assetKeyLabel(info.AssetKey.Path)
+			entry := entries[key]
+			entry.lastMaterializationStatus = info.LatestRun.Status
+			entries[key] = entry
+		}
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.assetStatus = entries
+
+	return nil
+}
+
+// assetKeyLabel joins an asset key's path segments into a single Prometheus
+// label value, e.g. ["my_dbt_project", "customers"] becomes
+// "my_dbt_project/customers" — the same separator Dagster's own UI uses to
+// render an asset key.
+func assetKeyLabel(path AssetKeyPath) string {
+	return strings.Join(path, "/")
+}
+
+// reflectAssetStatus emits dagster_asset_stale_status and
+// dagster_asset_last_materialization_status from a single locked pass over
+// c.assetStatus, the same reasoning as reflectDaemonHealth: both come from
+// one entry per asset.
+func reflectAssetStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for assetKey, entry := range c.assetStatus {
+		if entry.staleStatus != "" {
+			ch <- prometheus.MustNewConstMetric(
+				c.assetStaleStatusDesc,
+				prometheus.GaugeValue,
+				1,
+				assetKey,
+				strings.ToLower(entry.staleStatus),
+			)
+		}
+
+		if entry.lastMaterializationStatus != "" {
+			ch <- prometheus.MustNewConstMetric(
+				c.assetLastMaterializationStatusDesc,
+				prometheus.GaugeValue,
+				1,
+				assetKey,
+				strings.ToLower(entry.lastMaterializationStatus),
+			)
+		}
+	}
+}

--- a/internal/collector/asset_status_test.go
+++ b/internal/collector/asset_status_test.go
@@ -1,0 +1,229 @@
+package collector
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assetStatusServer routes the two GraphQL queries CollectAssetStatus issues
+// (get_asset_nodes.graphql, then get_assets_latest_info.graphql) to separate
+// canned response bodies, keyed off which field name the request's query
+// text asks for — the same shape as a real Dagster endpoint, which answers
+// both from a single /graphql URL.
+func assetStatusServer(t *testing.T, nodesBody, latestInfoBody string) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		switch {
+		case strings.Contains(req.Query, "assetNodes"):
+			_, err := w.Write([]byte(nodesBody))
+			require.NoError(t, err)
+		case strings.Contains(req.Query, "assetsLatestInfo"):
+			_, err := w.Write([]byte(latestInfoBody))
+			require.NoError(t, err)
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestCollectAssetStatusDistinguishesNeverRunFromFailed exercises the reason
+// this collector needs a second query at all: assetNodes.staleStatus is
+// derived from assetMaterializations, which only records successful events,
+// so a failed run and "never run" both show up there as MISSING. Only
+// assetsLatestInfo.latestRun.status tells them apart (issue #56).
+func TestCollectAssetStatusDistinguishesNeverRunFromFailed(t *testing.T) {
+	nodesBody := `{
+		"data": {
+			"assetNodes": [
+				{"assetKey": {"path": ["good_asset"]}, "staleStatus": "FRESH"},
+				{"assetKey": {"path": ["bad_asset"]}, "staleStatus": "MISSING"},
+				{"assetKey": {"path": ["never_run_asset"]}, "staleStatus": "MISSING"}
+			]
+		}
+	}`
+	latestInfoBody := `{
+		"data": {
+			"assetsLatestInfo": [
+				{"assetKey": {"path": ["good_asset"]}, "latestRun": {"status": "SUCCESS"}},
+				{"assetKey": {"path": ["bad_asset"]}, "latestRun": {"status": "FAILURE"}},
+				{"assetKey": {"path": ["never_run_asset"]}, "latestRun": null}
+			]
+		}
+	}`
+	ts := assetStatusServer(t, nodesBody, latestInfoBody)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	require.NoError(t, CollectAssetStatus(t.Context(), c))
+
+	require.Len(t, c.assetStatus, 3)
+	assert.Equal(t, assetStatusEntry{staleStatus: "FRESH", lastMaterializationStatus: "SUCCESS"}, c.assetStatus["good_asset"])
+	assert.Equal(t, assetStatusEntry{staleStatus: "MISSING", lastMaterializationStatus: "FAILURE"}, c.assetStatus["bad_asset"],
+		"a failed run must be distinguishable from an asset that has never run, even though both look MISSING via staleStatus alone")
+	assert.Equal(t, assetStatusEntry{staleStatus: "MISSING", lastMaterializationStatus: ""}, c.assetStatus["never_run_asset"])
+}
+
+// TestCollectAssetStatusJoinsMultiSegmentAssetKeys checks the "/"-joined
+// label value for an asset key with more than one path segment (e.g. a dbt
+// project and model name), the common case in practice.
+func TestCollectAssetStatusJoinsMultiSegmentAssetKeys(t *testing.T) {
+	nodesBody := `{
+		"data": {
+			"assetNodes": [
+				{"assetKey": {"path": ["my_dbt_project", "customers"]}, "staleStatus": "STALE"}
+			]
+		}
+	}`
+	latestInfoBody := `{
+		"data": {
+			"assetsLatestInfo": [
+				{"assetKey": {"path": ["my_dbt_project", "customers"]}, "latestRun": {"status": "SUCCESS"}}
+			]
+		}
+	}`
+	ts := assetStatusServer(t, nodesBody, latestInfoBody)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	require.NoError(t, CollectAssetStatus(t.Context(), c))
+
+	require.Contains(t, c.assetStatus, "my_dbt_project/customers")
+}
+
+// TestCollectAssetStatusHandlesNullStaleStatus checks the nullable
+// staleStatus field: an asset with no computable stale status must end up
+// with an empty staleStatus, not a literal "null" or "<nil>" label value.
+func TestCollectAssetStatusHandlesNullStaleStatus(t *testing.T) {
+	nodesBody := `{
+		"data": {
+			"assetNodes": [
+				{"assetKey": {"path": ["no_stale_status_asset"]}, "staleStatus": null}
+			]
+		}
+	}`
+	latestInfoBody := `{
+		"data": {
+			"assetsLatestInfo": [
+				{"assetKey": {"path": ["no_stale_status_asset"]}, "latestRun": null}
+			]
+		}
+	}`
+	ts := assetStatusServer(t, nodesBody, latestInfoBody)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	require.NoError(t, CollectAssetStatus(t.Context(), c))
+
+	require.Contains(t, c.assetStatus, "no_stale_status_asset")
+	assert.Equal(t, "", c.assetStatus["no_stale_status_asset"].staleStatus)
+}
+
+// TestCollectAssetStatusSkipsLatestInfoQueryWhenNoAssetsDefined checks that
+// an empty assetNodes result short-circuits before asking assetsLatestInfo
+// for zero asset keys — a request the schema doesn't reject, but that's
+// pure waste when the answer is already known to be empty.
+func TestCollectAssetStatusSkipsLatestInfoQueryWhenNoAssetsDefined(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if strings.Contains(req.Query, "assetsLatestInfo") {
+			t.Fatal("assetsLatestInfo should not be queried when assetNodes returned nothing")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"data": {"assetNodes": []}}`))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	require.NoError(t, CollectAssetStatus(t.Context(), c))
+	assert.Empty(t, c.assetStatus)
+}
+
+// TestCollectAssetStatusReturnsErrorOnGraphQLError checks that a top-level
+// GraphQL error from the first query is propagated rather than treated as
+// "no assets".
+func TestCollectAssetStatusReturnsErrorOnGraphQLError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"errors": [{"message": "boom"}]}`))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	err := CollectAssetStatus(t.Context(), c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestReflectAssetStatus(t *testing.T) {
+	c := NewDagsterCollector(t.Context(), "http://unused", time.Hour, time.Hour, 500, 5*time.Minute)
+	c.assetStatus = map[string]assetStatusEntry{
+		"good_asset":      {staleStatus: "FRESH", lastMaterializationStatus: "SUCCESS"},
+		"never_run_asset": {staleStatus: "MISSING", lastMaterializationStatus: ""},
+	}
+
+	ch := make(chan prometheus.Metric, 8)
+	go func() {
+		reflectAssetStatus(c, ch)
+		close(ch)
+	}()
+
+	type key struct {
+		metric   string
+		assetKey string
+		status   string
+	}
+	seen := make(map[key]float64)
+	for m := range ch {
+		var dm dto.Metric
+		require.NoError(t, m.Write(&dm))
+
+		desc := m.Desc().String()
+		var metricName string
+		switch {
+		case strings.Contains(desc, "dagster_asset_stale_status"):
+			metricName = "dagster_asset_stale_status"
+		case strings.Contains(desc, "dagster_asset_last_materialization_status"):
+			metricName = "dagster_asset_last_materialization_status"
+		default:
+			t.Fatalf("unexpected metric desc: %s", desc)
+		}
+
+		var assetKey, status string
+		for _, l := range dm.GetLabel() {
+			switch l.GetName() {
+			case "asset_key":
+				assetKey = l.GetValue()
+			case "status":
+				status = l.GetValue()
+			}
+		}
+		seen[key{metricName, assetKey, status}] = dm.GetGauge().GetValue()
+	}
+
+	assert.Equal(t, float64(1), seen[key{"dagster_asset_stale_status", "good_asset", "fresh"}])
+	assert.Equal(t, float64(1), seen[key{"dagster_asset_last_materialization_status", "good_asset", "success"}])
+	assert.Equal(t, float64(1), seen[key{"dagster_asset_stale_status", "never_run_asset", "missing"}])
+	assert.Len(t, seen, 3,
+		"never_run_asset must not emit a dagster_asset_last_materialization_status series: it has no run to report a status for")
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -12,24 +12,26 @@ import (
 type DagsterCollector struct {
 	dagsterGraphQLEndpoint string
 
-	activeRunsDesc            *prometheus.Desc
-	completedRunsCounter      *prometheus.CounterVec
-	lastRunStatusDesc         *prometheus.Desc
-	scrapeDurationDesc        *prometheus.Desc
-	lastScrapeSuccessDesc     *prometheus.Desc
-	scrapeErrorsCounter       *prometheus.CounterVec
-	codeLocationLoadErrorDesc *prometheus.Desc
-	lastRunDurationDesc       *prometheus.Desc
-	activeRunDurationDesc     *prometheus.Desc
-	concurrencyKeyBacklogDesc *prometheus.Desc
-	scheduleStatusDesc        *prometheus.Desc
-	scheduleTickStatusDesc    *prometheus.Desc
-	scheduleTickTimestampDesc *prometheus.Desc
-	sensorStatusDesc          *prometheus.Desc
-	sensorTickStatusDesc      *prometheus.Desc
-	sensorTickTimestampDesc   *prometheus.Desc
-	daemonHealthyDesc         *prometheus.Desc
-	daemonLastHeartbeatDesc   *prometheus.Desc
+	activeRunsDesc                     *prometheus.Desc
+	completedRunsCounter               *prometheus.CounterVec
+	lastRunStatusDesc                  *prometheus.Desc
+	scrapeDurationDesc                 *prometheus.Desc
+	lastScrapeSuccessDesc              *prometheus.Desc
+	scrapeErrorsCounter                *prometheus.CounterVec
+	codeLocationLoadErrorDesc          *prometheus.Desc
+	lastRunDurationDesc                *prometheus.Desc
+	activeRunDurationDesc              *prometheus.Desc
+	concurrencyKeyBacklogDesc          *prometheus.Desc
+	scheduleStatusDesc                 *prometheus.Desc
+	scheduleTickStatusDesc             *prometheus.Desc
+	scheduleTickTimestampDesc          *prometheus.Desc
+	sensorStatusDesc                   *prometheus.Desc
+	sensorTickStatusDesc               *prometheus.Desc
+	sensorTickTimestampDesc            *prometheus.Desc
+	daemonHealthyDesc                  *prometheus.Desc
+	daemonLastHeartbeatDesc            *prometheus.Desc
+	assetStaleStatusDesc               *prometheus.Desc
+	assetLastMaterializationStatusDesc *prometheus.Desc
 
 	mutex                   sync.Mutex
 	activeRunAggregates     map[ActiveRunKey]activeRunAggregate
@@ -48,6 +50,7 @@ type DagsterCollector struct {
 	scrapeResults           map[string]scrapeResult
 	codeLocationLoadError   map[string]bool
 	daemonHealth            map[string]daemonHealthEntry
+	assetStatus             map[string]assetStatusEntry
 	// runsUpdatedAfterSafetyMargin is subtracted from the last-seen
 	// updateTime watermark before it's used as the next scrape's
 	// updatedAfter. A run's updateTime can be set slightly before its write
@@ -189,6 +192,18 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"daemon_type"},
 			nil,
 		),
+		assetStaleStatusDesc: prometheus.NewDesc(
+			"dagster_asset_stale_status",
+			"Whether an asset's data is missing, stale, or fresh (value is always 1; status is carried in the status label, one of missing/stale/fresh). Absent for an asset Dagster reports no computable stale status for",
+			[]string{"asset_key", "status"},
+			nil,
+		),
+		assetLastMaterializationStatusDesc: prometheus.NewDesc(
+			"dagster_asset_last_materialization_status",
+			"Status of an asset's most recent materializing run (value is always 1; status is carried in the status label). Absent for an asset that has never had a run — unlike stale status, this is derived from the run itself rather than assetMaterializations, so a run that fails before producing a materialization still shows up here (see docs/metrics.md)",
+			[]string{"asset_key", "status"},
+			nil,
+		),
 		processedRuns:                cache,
 		lookbackWindow:               lookbackWindow,
 		lastRunStatus:                make(map[JobKey]lastRunEntry),
@@ -216,6 +231,8 @@ func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.sensorTickTimestampDesc
 	ch <- c.daemonHealthyDesc
 	ch <- c.daemonLastHeartbeatDesc
+	ch <- c.assetStaleStatusDesc
+	ch <- c.assetLastMaterializationStatusDesc
 	c.completedRunsCounter.Describe(ch)
 	c.scrapeErrorsCounter.Describe(ch)
 }
@@ -231,6 +248,7 @@ func (c *DagsterCollector) Collect(ch chan<- prometheus.Metric) {
 	reflectSensorStatus(c, ch)
 	reflectSensorTickStatus(c, ch)
 	reflectDaemonHealth(c, ch)
+	reflectAssetStatus(c, ch)
 	c.completedRunsCounter.Collect(ch)
 	c.scrapeErrorsCounter.Collect(ch)
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -25,9 +25,10 @@ func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
 	// concurrencyKeyBacklogDesc, scheduleStatusDesc, scheduleTickStatusDesc,
 	// scheduleTickTimestampDesc, sensorStatusDesc, sensorTickStatusDesc,
 	// sensorTickTimestampDesc, daemonHealthyDesc, daemonLastHeartbeatDesc,
+	// assetStaleStatusDesc, assetLastMaterializationStatusDesc,
 	// plus one each from completedRunsCounter and
 	// scrapeErrorsCounter.
-	assert.Equal(t, 18, descCount)
+	assert.Equal(t, 20, descCount)
 
 	c.RecordScrapeResult("active_runs", 10*time.Millisecond, nil)
 

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -425,6 +425,104 @@ func getDaemonHealth(ctx context.Context, request *GraphQLRequest, dagsterGraphQ
 	return &resp, nil
 }
 
+// AssetKeyPath is a Dagster asset key: an ordered path (e.g. a dbt project
+// and model name), not a single string. assetKeyLabel joins it into the
+// Prometheus label value.
+type AssetKeyPath []string
+
+// GraphQLAssetNodesResponse is the shape of assetNodes: every asset
+// currently defined, across every code location, in one fetch — unlike
+// repositoriesOrError, assetNodes takes no repositorySelector and isn't
+// nested under a per-location union, so there's no __typename to check here
+// (the same reasoning as GraphQLDaemonHealthResponse).
+//
+// staleStatus is nullable in the schema (an asset can have no computable
+// staleness, e.g. one with no defined freshness policy or partitions
+// Dagster hasn't evaluated yet), hence the pointer.
+type GraphQLAssetNodesResponse struct {
+	Data struct {
+		AssetNodes []struct {
+			AssetKey struct {
+				Path AssetKeyPath `json:"path"`
+			} `json:"assetKey"`
+			StaleStatus *string `json:"staleStatus"`
+		} `json:"assetNodes"`
+	} `json:"data"`
+	graphQLErrors
+}
+
+//go:embed queries/get_asset_nodes.graphql
+var assetNodesQuery string
+
+func getAssetNodesRequest() *GraphQLRequest {
+	return &GraphQLRequest{
+		Query: assetNodesQuery,
+	}
+}
+
+func getAssetNodes(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLAssetNodesResponse, error) {
+	var resp GraphQLAssetNodesResponse
+	if err := doGraphQL(ctx, request, dagsterGraphQLEndpoint, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// GraphQLAssetsLatestInfoResponse is the shape of assetsLatestInfo, queried
+// separately from assetNodes (see CollectAssetStatus) because it needs the
+// asset keys assetNodes just returned.
+//
+// latestRun is nullable: an asset that has never had a materializing run
+// attempted has no run to report a status for. assetMaterializations would
+// answer a related but different question and can't stand in for this one —
+// it only ever records successful events, so a run that failed before
+// producing a materialization leaves no trace there at all (issue #56).
+type GraphQLAssetsLatestInfoResponse struct {
+	Data struct {
+		AssetsLatestInfo []struct {
+			AssetKey struct {
+				Path AssetKeyPath `json:"path"`
+			} `json:"assetKey"`
+			LatestRun *struct {
+				Status string `json:"status"`
+			} `json:"latestRun"`
+		} `json:"assetsLatestInfo"`
+	} `json:"data"`
+	graphQLErrors
+}
+
+//go:embed queries/get_assets_latest_info.graphql
+var assetsLatestInfoQuery string
+
+// assetKeyInput is the wire shape GraphQL's AssetKeyInput expects: an object
+// wrapping the path, not the bare array AssetKeyPath marshals to on its own.
+type assetKeyInput struct {
+	Path AssetKeyPath `json:"path"`
+}
+
+func getAssetsLatestInfoRequest(assetKeys []AssetKeyPath) *GraphQLRequest {
+	inputs := make([]assetKeyInput, len(assetKeys))
+	for i, path := range assetKeys {
+		inputs[i] = assetKeyInput{Path: path}
+	}
+	return &GraphQLRequest{
+		Query: assetsLatestInfoQuery,
+		Variables: map[string]interface{}{
+			"assetKeys": inputs,
+		},
+	}
+}
+
+func getAssetsLatestInfo(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLAssetsLatestInfoResponse, error) {
+	var resp GraphQLAssetsLatestInfoResponse
+	if err := doGraphQL(ctx, request, dagsterGraphQLEndpoint, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 //go:embed queries/get_version.graphql
 var versionQuery string
 

--- a/internal/collector/queries/get_asset_nodes.graphql
+++ b/internal/collector/queries/get_asset_nodes.graphql
@@ -1,0 +1,8 @@
+query GetAssetNodes {
+  assetNodes {
+    assetKey {
+      path
+    }
+    staleStatus
+  }
+}

--- a/internal/collector/queries/get_assets_latest_info.graphql
+++ b/internal/collector/queries/get_assets_latest_info.graphql
@@ -1,0 +1,10 @@
+query GetAssetsLatestInfo($assetKeys: [AssetKeyInput!]!) {
+  assetsLatestInfo(assetKeys: $assetKeys) {
+    assetKey {
+      path
+    }
+    latestRun {
+      status
+    }
+  }
+}

--- a/internal/server/scrape.go
+++ b/internal/server/scrape.go
@@ -30,6 +30,7 @@ func scrapeDagster(ctx context.Context, c *collector.DagsterCollector) {
 	spawn("completed_runs", collector.CollectCompletedRuns)
 	spawn("code_location_status", collector.CollectCodeLocationStatus)
 	spawn("daemon_health", collector.CollectDaemonHealth)
+	spawn("asset_status", collector.CollectAssetStatus)
 
 	wg.Wait()
 }


### PR DESCRIPTION
## What

A sixth collector (`CollectAssetStatus`), and two metrics:

| Metric | Labels |
|---|---|
| `dagster_asset_stale_status` | `asset_key`, `status` (`missing`/`stale`/`fresh`) |
| `dagster_asset_last_materialization_status` | `asset_key`, `status` (e.g. `success`, `failure`) |

Plus `good_asset`/`bad_asset` in the dev fixture, `Asset Stale Status`/`Asset Last Materialization Status` Grafana panels, and the docs.

`asset_key` is the key's path segments joined with `/` (e.g. `my_dbt_project/customers`) — the same separator Dagster's own UI uses.

## Why two metrics instead of one

This collector makes two GraphQL round trips, not one, and that's the load-bearing part of the design.

`assetNodes.staleStatus` looks like it should answer "is this asset okay", but it's derived from `assetMaterializations`, which **only ever records successful events**. A run that fails before producing a materialization leaves no trace there — so a failing asset and one that has simply never run both report `missing`. Confirmed live: materializing `bad_asset` (which always raises) leaves `staleStatus: MISSING`, identical to before it ever ran.

Only `assetsLatestInfo.latestRun.status` reads the run itself rather than its output, so it's the only field that tells the two apart. It needs the asset keys as input, so `assetNodes` has to run first — hence two queries. Neither field is reachable via `repositoriesOrError`, so this is a new independent collector (same reasoning as `CollectCodeLocationStatus`/`CollectDaemonHealth`).

## QA

Followed the `verify-metric` workflow end to end: `docker compose up` (real Dagster + exporter + Prometheus + Grafana), materialized both fixture assets via GraphQL (`good_asset` succeeds, `bad_asset` always raises).

`/metrics`:

```
dagster_asset_last_materialization_status{asset_key="bad_asset",status="failure"} 1
dagster_asset_last_materialization_status{asset_key="good_asset",status="success"} 1
dagster_asset_stale_status{asset_key="bad_asset",status="missing"} 1
dagster_asset_stale_status{asset_key="good_asset",status="fresh"} 1
```

Confirmed in Prometheus via `/api/v1/query`, then swept every panel in the dashboard against Prometheus (23 panels total):

```
ok     Asset Stale Status                     2 series
ok     Asset Last Materialization Status      2 series
```

All other panels `ok` except the pre-existing `Run Queue Backlog by Concurrency Key`, which was `EMPTY` for an unrelated, expected reason (that panel's condition — 3+ `heavy_job` runs — wasn't created in this session).

Also confirmed via the Grafana API that the provisioned dashboard actually contains both new panels (not just that the underlying PromQL resolves).

`go build` / `go vet` / `go test -race` / `golangci-lint` / `go mod tidy` clean. `uvx ruff check .` clean (the fixture's fixed line length). Dashboard JSON still `jq`-formatted.

## Ref

Closes #56.