### PR TITLE
Commit the Claude Code skills used to develop this repo

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: create-pr
+description: Create (or update) a GitHub pull request for the current branch in this repo. Use whenever the user asks to open, create, or update a PR. Fills in this repo's PR template and writes the title/body in English, even if the conversation is in Japanese.
+---
+
+# Create PR
+
+Create a pull request for the current branch against `main`, following this
+repo's PR template.
+
+## Steps
+
+1. **Name the branch `<type>/<short-slug>`** when creating a new branch for
+   the work (before starting, not at PR time). `<type>` mirrors Conventional
+   Commit types — `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`,
+   `perf`, `build` — picked to match the nature of the change. `<slug>` is a
+   short kebab-case description (e.g. `docs/contributing-and-issue-templates`,
+   `fix/dashboard-location-label`). Do **not** put issue numbers in the
+   branch name — link issues from the PR body's `Ref` section instead (see
+   step 4), since a branch name shouldn't need updating if the issue's scope
+   shifts.
+
+2. **Check state.** Run `git status`, `git log main..HEAD`, and
+   `git diff main...HEAD` to see what's actually being shipped. If there are
+   uncommitted changes relevant to the PR, ask the user before including
+   them — don't silently commit unrelated work.
+
+3. **Push the branch** if it isn't already tracked upstream:
+   `git push -u origin <branch>`.
+
+4. **Read the template** at `.github/PULL_REQUEST_TEMPLATE.md` (sections:
+   `What` / `Why` / `QA` / `Ref`) and fill in each section based on the
+   actual diff and commits — don't invent content that isn't supported by
+   the change. Reference any related issue in the `Ref` section (e.g.
+   `Closes #26`), rather than encoding it in the branch name.
+
+5. **Language: always write the PR title and body in English**, regardless
+   of what language the conversation with the user is in. This applies to
+   both new PRs and edits to existing ones.
+
+6. **Create or update the PR using `gh api`, not `gh pr create --body` /
+   `gh pr edit --body`.** In this repo/account, `gh pr create` and
+   `gh pr edit` intermittently fail with:
+
+   ```
+   GraphQL: Projects (classic) is being deprecated in favor of the new
+   Projects experience ... (repository.pullRequest.projectCards)
+   ```
+
+   This comes from the `gh` CLI's own follow-up GraphQL query for extra
+   fields (deprecated project cards) after the mutation, not from the
+   mutation itself — the PR create/update can partially succeed while `gh`
+   still reports an error, which is confusing. Avoid it entirely by calling
+   the REST API directly:
+
+   - New PR:
+     ```bash
+     gh api -X POST repos/{owner}/{repo}/pulls \
+       -f title="..." \
+       -f head="<branch>" \
+       -f base="main" \
+       -f body="$(cat <<'EOF'
+     ...body text...
+     EOF
+     )"
+     ```
+   - Update an existing PR's body/title:
+     ```bash
+     gh api -X PATCH repos/{owner}/{repo}/pulls/{number} \
+       -f body="$(cat <<'EOF'
+     ...body text...
+     EOF
+     )"
+     ```
+
+   Get `{owner}/{repo}` from `git remote get-url origin` if not already
+   known.
+
+7. **Verify** by reading back the result (`gh pr view <number> --json
+   url,title,body -q ...` or the API response) and report the PR URL to the
+   user.

--- a/.claude/skills/verify-metric/SKILL.md
+++ b/.claude/skills/verify-metric/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: verify-metric
+description: Verify a Dagster exporter metric end to end against the real dev stack — create the condition in Dagster, confirm the series reaches /metrics and Prometheus, and confirm the Grafana panel actually renders it. Use whenever adding or changing a metric, or when a metric is suspected of not working. Unit tests with mocked GraphQL cannot catch a query Dagster answers differently than the mock does.
+---
+
+# Verify a metric end to end
+
+Unit tests here mock Dagster's GraphQL, so they prove the Go code handles a
+response — not that Dagster produces that response. Three separate bugs
+(#69, #70, #85) were all invisible to a green CI. The worst was #85: the
+schedule and sensor tick metrics were implemented, tested, documented, and
+had Grafana panels, but had **never emitted a single series** on a real
+instance, because `ticks(limit: 1)` needs a time bound that the mock didn't
+model. It went unnoticed for weeks.
+
+Finish the loop: create the condition in Dagster, then follow the data
+through the exporter, Prometheus, and the dashboard panel.
+
+## Steps
+
+1. **Bring up the whole stack**, not just Dagster. The panel check at the end
+   needs Prometheus and Grafana too.
+
+   ```sh
+   docker compose up -d --build
+   ```
+
+   Services: Dagster `:3000`, exporter `:9101`, Prometheus `:9090`, Grafana
+   `:3001` (`root` / `passw0rd`, dashboard pre-provisioned).
+
+2. **Wait for readiness** rather than sleeping a fixed amount:
+
+   ```sh
+   until curl -sf http://127.0.0.1:9090/-/ready >/dev/null \
+      && curl -sf http://127.0.0.1:3001/api/health >/dev/null \
+      && curl -sf http://127.0.0.1:9101/metrics >/dev/null; do sleep 5; done
+   ```
+
+3. **Create the condition the metric measures.** This is the step that gets
+   skipped, and the reason a panel can sit empty for weeks without anyone
+   noticing.
+
+   Some conditions already exist in `dev/dagster_workspace/job.py`, running
+   automatically:
+
+   | Fixture | Produces |
+   | --- | --- |
+   | `quick_job_schedule` | schedule ticking `success` every minute |
+   | `quick_job_sensor` | sensor ticking `skipped` every 30s |
+   | `failing_sensor` | sensor ticking `failure` every 30s |
+   | `broken_location` | code-location load error (opt-in: `dagster dev -w dev/workspace.yaml`) |
+
+   Others have to be triggered. The run-queue backlog, for instance, needs
+   more runs than the concurrency limit in `dev/dagster_home/dagster.yaml`
+   allows (`heavy_limit`, limit 1), so launch three and two will queue:
+
+   ```sh
+   curl -s -X POST http://127.0.0.1:3000/graphql -H 'Content-Type: application/json' -d '{
+     "query": "mutation($e: ExecutionParams!) { launchPipelineExecution(executionParams: $e) { __typename ... on LaunchRunSuccess { run { runId status } } ... on PythonError { message } } }",
+     "variables": {"e": {"selector": {"repositoryLocationName": "dev-dagster-workspace", "repositoryName": "__repository__", "jobName": "heavy_job"}, "mode": "default"}}
+   }' | jq -c '.data.launchPipelineExecution'
+   ```
+
+   If no fixture produces the condition, **add one**. A metric that can't be
+   produced locally can't be verified locally, and its dashboard panel can't
+   be checked by anyone.
+
+4. **Confirm the series reaches `/metrics`.** Both scrape intervals are 15s
+   (exporter → Dagster, Prometheus → exporter), so allow ~30s end to end.
+
+   ```sh
+   curl -s http://127.0.0.1:9101/metrics | grep '^dagster_<metric_name>'
+   ```
+
+   Absent here means the collector isn't producing it — check the exporter
+   logs and query Dagster's GraphQL directly to see what it really returns.
+   Do not assume the query is right because a unit test passes.
+
+5. **Confirm Prometheus ingested it:**
+
+   ```sh
+   curl -s -G --data-urlencode 'query=dagster_<metric_name>' \
+     http://127.0.0.1:9090/api/v1/query | jq '.data.result'
+   ```
+
+6. **Sweep every dashboard panel.** This is the check that would have caught
+   #85 immediately, and it covers panels beyond the one just changed:
+
+   ```sh
+   jq -r '.panels[] | .title as $t | (.targets[]? | select(.expr) | "\($t)\t\(.expr)")' \
+     dev/grafana/dashboards/dagster-dashboard.json \
+   | while IFS=$'\t' read -r title expr; do
+       q=$(printf '%s' "$expr" | sed 's/\$__rate_interval/5m/g; s/\$__interval/1m/g')
+       r=$(curl -s -G --data-urlencode "query=$q" http://127.0.0.1:9090/api/v1/query)
+       n=$(printf '%s' "$r" | jq '.data.result | length // 0')
+       s=$(printf '%s' "$r" | jq -r '.status')
+       if [ "$s" != "success" ]; then m="ERROR"; elif [ "$n" -eq 0 ]; then m="EMPTY"; else m="ok   "; fi
+       printf '%s  %-36s %s series\n' "$m" "$title" "$n"
+     done
+   ```
+
+   `EMPTY` is not automatically a bug — it means *find out why*. Either the
+   condition wasn't created (step 3), or the metric is broken. Never leave an
+   `EMPTY` unexplained; that is exactly the state #85 lived in.
+
+7. **Check the panel has somewhere to render.** If the metric is new and no
+   panel queries it, add one to
+   `dev/grafana/dashboards/dagster-dashboard.json`. A metric nobody can see
+   is a metric nobody will notice is broken. CI requires the file stay
+   `jq`-formatted:
+
+   ```sh
+   diff <(jq . dev/grafana/dashboards/dagster-dashboard.json) dev/grafana/dashboards/dagster-dashboard.json
+   ```
+
+8. **Record what was observed in the PR.** Paste the actual `/metrics` lines
+   and the panel sweep output. "Verified locally" without the output is not
+   evidence — for #85 the unit tests were green the whole time.
+
+9. **Tear down:**
+
+   ```sh
+   docker compose down --remove-orphans
+   ```
+
+## When a metric can't be produced locally
+
+Some can't be, and that's worth stating rather than papering over. A
+workspace-level `PythonError` needs a deliberately broken Dagster, so #69
+was covered by mocks and the PR said so explicitly. That's fine — what isn't
+fine is claiming end-to-end verification that didn't happen. Say which parts
+were checked live and which were mocked.

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ dev/dagster_home/history/
 dev/dagster_home/schedules/
 dev/dagster_home/storage/
 dev/dagster_home/logs/
+
+# Claude Code: settings.json (shared) is committed; settings.local.json is a
+# per-user permission allowlist and isn't meant to be shared.
+.claude/settings.local.json


### PR DESCRIPTION
## What

Adds `.claude/skills/verify-metric/SKILL.md` and `.claude/skills/create-pr/SKILL.md` to the repo. Both were previously local-only (`.claude/` was never committed).

`.claude/settings.local.json` stays out — it's a per-user permission allowlist, not project knowledge — and is now in `.gitignore` so it doesn't get committed by accident later.

## Why

`verify-metric` is already referenced by name in past PR descriptions (#88, #95: "Followed the `verify-metric` workflow end to end") as the actual evidence for a change working — but until now nobody outside this checkout could read what that workflow is.

It exists because three real bugs (#69, #70, #85) were all invisible to a green CI. Unit tests here mock Dagster's GraphQL API, which proves the Go code handles a given response, not that Dagster actually produces it. #85 was the worst case: the schedule/sensor tick metrics were implemented, unit tested, documented, and had a Grafana panel — and had never emitted a single series against a real Dagster instance, for weeks, because `ticks(limit: 1)` needs a time bound the mock didn't model.

`create-pr` documents this repo's own conventions (branch naming, PR template sections, and a `gh pr create`/`gh pr edit` GraphQL error this account hits intermittently, worked around by calling the REST API directly) so they don't have to be rediscovered.

## QA

Both files reviewed for secrets/machine-specific content — neither has any. Confirmed `.claude/settings.local.json` is excluded from `git status` after the `.gitignore` change.

## Ref

N/A — repo tooling, not tied to an issue.