### PR TITLE
Add a test that lists every metric family the exporter can produce

### DIFF
--- a/internal/server/metric_names_test.go
+++ b/internal/server/metric_names_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/HirofumiTsuda/dagster-prometheus-exporter/internal/collector"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// descFqNameRe pulls the metric name out of (*prometheus.Desc).String(),
+// e.g. `Desc{fqName: "dagster_active_runs", ...}`. client_golang has no
+// public accessor for a Desc's name, so this is the only way to read it
+// back without reaching into the package's internals.
+var descFqNameRe = regexp.MustCompile(`fqName: "([^"]+)"`)
+
+// TestListMetricNames prints every metric family this exporter can ever
+// produce on /metrics, one per line as "METRIC: <name>" — both
+// DagsterCollector's families and dagster_exporter_build_info, registered
+// the same way RunServer registers them.
+//
+// This is the single source of truth issue #90 asks for: helm-e2e.yml
+// derives its expected-metrics list from this test's output
+// (`go test -run TestListMetricNames -v`) instead of a hand-maintained
+// list that silently drifts from the real collector. That drift is exactly
+// how #85 went unnoticed for weeks — two entire metric families had never
+// emitted a single series, and nothing checked for their absence.
+//
+// Describe() is used rather than Gather(): Describe unconditionally sends
+// one Desc per metric family regardless of whether any data has been
+// observed yet. Gather() only returns a family once Collect() has actually
+// sent it a sample, so a freshly constructed, never-scraped
+// DagsterCollector would report almost nothing through it — every
+// in-memory map behind a per-asset/per-job/per-schedule metric starts
+// empty.
+func TestListMetricNames(t *testing.T) {
+	c := collector.NewDagsterCollector(t.Context(), "http://unused", time.Hour, time.Hour, 500, 5*time.Minute)
+	b := newBuildInfoGauge("test-version", "test-commit")
+
+	ch := make(chan *prometheus.Desc, 32)
+	go func() {
+		c.Describe(ch)
+		b.Describe(ch)
+		close(ch)
+	}()
+
+	names := make(map[string]struct{})
+	for desc := range ch {
+		m := descFqNameRe.FindStringSubmatch(desc.String())
+		if m == nil {
+			t.Fatalf("could not extract a metric name from Desc: %s", desc.String())
+		}
+		names[m[1]] = struct{}{}
+	}
+
+	sorted := make([]string, 0, len(names))
+	for name := range names {
+		sorted = append(sorted, name)
+	}
+	sort.Strings(sorted)
+
+	for _, name := range sorted {
+		fmt.Println("METRIC:", name)
+	}
+}


### PR DESCRIPTION
## What

`TestListMetricNames` (`go test -run TestListMetricNames -v ./internal/server/...`) prints every metric family this exporter can produce, one per line as `METRIC: <name>`:

```
METRIC: dagster_active_run_duration_seconds
METRIC: dagster_active_runs
METRIC: dagster_asset_last_materialization_status
METRIC: dagster_asset_stale_status
METRIC: dagster_code_location_load_error
METRIC: dagster_completed_runs_total
METRIC: dagster_daemon_healthy
METRIC: dagster_daemon_last_heartbeat_timestamp_seconds
METRIC: dagster_exporter_build_info
METRIC: dagster_exporter_last_scrape_success
METRIC: dagster_exporter_scrape_duration_seconds
METRIC: dagster_exporter_scrape_errors_total
METRIC: dagster_last_run_duration_seconds
METRIC: dagster_last_run_info
METRIC: dagster_run_queue_concurrency_key_backlog
METRIC: dagster_schedule_last_tick_status
METRIC: dagster_schedule_last_tick_timestamp_seconds
METRIC: dagster_schedule_status
METRIC: dagster_sensor_last_tick_status
METRIC: dagster_sensor_last_tick_timestamp_seconds
METRIC: dagster_sensor_status
```

21 families, derived from `DagsterCollector.Describe()` plus the separately-registered `dagster_exporter_build_info` gauge (`internal/server/build_info.go`) — the same two pieces `RunServer` registers. `Describe()` rather than `Gather()`, since `Describe()` unconditionally sends one `Desc` per family regardless of whether any data has been observed; a freshly constructed, never-scraped `DagsterCollector` would report almost nothing through `Gather()` — every per-asset/per-job/per-schedule map behind a metric starts empty.

## Why

This is step 1 of #90, split out on its own. `helm-e2e.yml` currently asserts only `dagster_active_runs` — one family out of what's now 21. That gap is exactly how #85 went unnoticed for weeks: two whole tick-status metric families had never emitted a single series, unit tests passed against mocks, and the e2e job never looked at them.

A follow-up PR will wire `helm-e2e.yml` to assert against this list instead of one hardcoded metric. Kept separate because that wiring has real open questions the original issue calls out — which families need a triggered condition before they can appear at all (e.g. `dagster_run_queue_concurrency_key_backlog` needs 3+ `heavy_job` runs), which families can't reasonably be asserted present in a healthy run at all (`dagster_exporter_scrape_errors_total` only appears once a scrape has failed), and how much extra kind-cluster runtime is acceptable — none of which belong in the same PR as this building block.

## QA

Ran directly and diffed the output against `docs/metrics.md`'s metric table — matches (21 families; the doc's table predates #56's two asset metrics, which do show up here). `go build` / `go vet` / `go test -race` / `golangci-lint` / `go mod tidy` clean.

## Ref

Part of #90.