### PR TITLE
Assert every metric family (that can appear without a trigger) in the e2e job

### DIFF
--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -35,6 +35,45 @@ jobs:
       # helm used for local chart testing.
       - uses: jdx/mise-action@v4
 
+      # For "Determine expected metric families" below — TestListMetricNames
+      # runs on the runner directly, not inside a container.
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      # See internal/server/metric_names_test.go and issue #90: this is the
+      # single source of truth for "which metric families should exist",
+      # so the assertion below checks all of them instead of the one
+      # (dagster_active_runs) it used to. #85 — two whole tick-status
+      # families that had never emitted a single series — would have been
+      # invisible to this job before this change, exactly like it was
+      # invisible to the unit tests mocking GraphQL.
+      - name: Determine expected metric families
+        run: |
+          go test -run TestListMetricNames -v ./internal/server/... \
+            | grep '^METRIC:' | sed 's/^METRIC: //' | sort > /tmp/expected-metrics.txt
+          echo "--- expected metric families ($(wc -l < /tmp/expected-metrics.txt)) ---"
+          cat /tmp/expected-metrics.txt
+
+          # Not asserted yet, each for a different reason:
+          #   dagster_run_queue_concurrency_key_backlog needs 3+ queued
+          #     heavy_job runs (its concurrency limit is 1) — no fixture
+          #     here creates that condition.
+          #   dagster_asset_last_materialization_status needs an asset to
+          #     actually be materialized — nothing here triggers one.
+          #   dagster_exporter_scrape_errors_total only appears once a
+          #     scrape has failed, which a healthy e2e run never does — it
+          #     can't be asserted present here even in principle.
+          # Tracked in #90 as follow-up work, not silently dropped.
+          cat > /tmp/not-yet-asserted.txt <<'NAMES'
+          dagster_run_queue_concurrency_key_backlog
+          dagster_asset_last_materialization_status
+          dagster_exporter_scrape_errors_total
+          NAMES
+          grep -vFxf /tmp/not-yet-asserted.txt /tmp/expected-metrics.txt > /tmp/expected-metrics-asserted.txt
+          echo "--- asserted this run ($(wc -l < /tmp/expected-metrics-asserted.txt) of $(wc -l < /tmp/expected-metrics.txt)) ---"
+          cat /tmp/expected-metrics-asserted.txt
+
       - name: Build exporter and Dagster dev images
         run: |
           docker build -f docker/exporter.Dockerfile -t dagster-prometheus-exporter-e2e:exporter .
@@ -56,7 +95,7 @@ jobs:
             -f dev/kubernetes/exporter-e2e-values.yaml \
             --wait --timeout=120s
 
-      - name: Assert /readyz and /metrics report real data
+      - name: Assert /readyz and every metric family reports real data
         run: |
           kubectl port-forward svc/exporter-e2e-dagster-prometheus-exporter 9101:9101 &
           PORT_FORWARD_PID=$!
@@ -71,20 +110,34 @@ jobs:
           echo "$READYZ"
           echo "$READYZ" | grep -q '"status":"OK"' || { echo "::error::exporter is not ready against the real Dagster instance"; exit 1; }
 
-          echo "--- /metrics (dagster_active_runs) ---"
+          echo "--- /metrics (waiting for every asserted family in expected-metrics-asserted.txt) ---"
           # /readyz being OK only proves live Dagster connectivity, not that
           # a background scrape has completed yet — the HTTP server and the
           # scraper goroutine start concurrently (see internal/server.go),
           # and the readinessProbe is /healthz (unconditionally 200), so the
-          # pod can be Ready before the first scrape lands. Poll for up to
-          # ~40s (a bit more than DAGSTER_SCRAPING_INTERVAL_SECONDS' 15s
-          # default) instead of asserting on a single sample.
-          for i in $(seq 1 20); do
+          # pod can be Ready before the first scrape lands. Most families
+          # are zero-filled from the very first scrape (a scrape interval
+          # of 15s), but the tick-status/timestamp families and
+          # dagster_last_run_info/_duration_seconds need the dev fixture's
+          # schedule (cron "* * * * *") or sensors (30s interval) to have
+          # actually ticked at least once — up to ~60s in the worst case.
+          # Poll for up to ~100s total rather than asserting on one sample.
+          MISSING=""
+          for i in $(seq 1 50); do
             METRICS=$(curl -sf http://localhost:9101/metrics)
-            echo "$METRICS" | grep -q '^dagster_active_runs{' && break
+            MISSING=""
+            while read -r name; do
+              echo "$METRICS" | grep -q "^${name}{" || MISSING="$MISSING $name"
+            done < /tmp/expected-metrics-asserted.txt
+            [ -z "$MISSING" ] && break
             sleep 2
           done
-          echo "$METRICS" | grep '^dagster_active_runs{' || { echo "::error::no dagster_active_runs series found after waiting for a scrape — exporter isn't reporting real data"; exit 1; }
+
+          if [ -n "$MISSING" ]; then
+            echo "::error::the following metric families never appeared on /metrics after waiting: ${MISSING# }"
+            exit 1
+          fi
+          echo "all $(wc -l < /tmp/expected-metrics-asserted.txt) asserted metric families are present"
 
           kill "$PORT_FORWARD_PID"
 


### PR DESCRIPTION
## What

Step 2 of #90 (step 1 was #97). `helm-e2e.yml` previously checked for exactly one metric family, `dagster_active_runs`. It now derives the full expected list from `TestListMetricNames` and polls `/metrics` until every asserted family is present, reporting every missing name on failure instead of just "no data" for one metric.

**18 of 21 families are asserted this run:**

| Group | Families | Why they need no explicit trigger |
|---|---|---|
| Zero-filled from the first scrape | `active_runs`, `active_run_duration_seconds`, `completed_runs_total`, `code_location_load_error`, `daemon_healthy`, `daemon_last_heartbeat_timestamp_seconds`, the 3 exporter self-health gauges, `build_info`, `schedule_status`, `sensor_status`, `asset_stale_status` | Seeded for every known job/location/asset regardless of activity — see `active_runs.go`'s seeding loop, `completed_runs.go`'s `seedCompletedRunsCounter`, `schedules.go`/`sensors.go`'s unconditional `status` field |
| Need a schedule/sensor tick (no trigger, just time) | `schedule_last_tick_status`/`_timestamp_seconds`, `sensor_last_tick_status`/`_timestamp_seconds`, `last_run_info`, `last_run_duration_seconds` | The dev fixture's schedule (`* * * * *`) and sensors (30s interval) already run unconditionally; the poll window grew from ~40s to ~100s to cover the schedule's up-to-60s cron boundary |

**Not asserted yet, each excluded with a reason written into the workflow itself:**

- `dagster_run_queue_concurrency_key_backlog` — needs 3+ queued `heavy_job` runs (limit is 1); nothing in this job triggers that
- `dagster_asset_last_materialization_status` — needs an asset to actually be materialized; nothing in this job triggers that
- `dagster_exporter_scrape_errors_total` — only appears once a scrape has failed, which a healthy e2e run never does — can't be asserted present here even in principle

Adding triggers for the first two is left as further #90 follow-up, kept out of this PR on purpose (same reasoning as splitting this from #97).

## Why

Before this, a regression in 20 of 21 metric families could ship silently through this job. That's exactly the shape of #85: two whole tick-status families had never emitted a single series, for weeks, and the only real-Dagster CI check never looked at them.

## QA

The classification above isn't guesswork — read the actual collector source for each family before deciding which bucket it belongs to, rather than assuming from behavior.

Both new script blocks in the workflow were rehearsed locally rather than only reviewed:
- Extracted the exact `run:` text GitHub Actions would execute via an actual YAML parse (not eyeballing indentation) and confirmed the heredoc survives the block-scalar indentation correctly
- Ran the "Determine expected metric families" step for real: 21 total, 18 asserted, matching the table above
- Exercised the missing-metric detection loop against both an incomplete and a complete fake `/metrics` blob — correctly reports the missing names in the incomplete case, empty in the complete case
- Confirmed `set -e` (GitHub Actions' default `-eo pipefail`) does not abort the script on a failing `&&`/`grep -q ... ||` inside the polling loop, which the logic depends on

Not run against a real kind cluster in this session (the workflow only triggers on `schedule`/`workflow_dispatch`, not on PRs) — will trigger it manually via `workflow_dispatch` on this branch before merging to confirm the real timing holds up.

## Ref

Part of #90.