### PR TITLE
Assert the two remaining triggerable metric families in helm-e2e.yml

### DIFF
--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -55,19 +55,16 @@ jobs:
           echo "--- expected metric families ($(wc -l < /tmp/expected-metrics.txt)) ---"
           cat /tmp/expected-metrics.txt
 
-          # Not asserted yet, each for a different reason:
-          #   dagster_run_queue_concurrency_key_backlog needs 3+ queued
-          #     heavy_job runs (its concurrency limit is 1) — no fixture
-          #     here creates that condition.
-          #   dagster_asset_last_materialization_status needs an asset to
-          #     actually be materialized — nothing here triggers one.
-          #   dagster_exporter_scrape_errors_total only appears once a
-          #     scrape has failed, which a healthy e2e run never does — it
-          #     can't be asserted present here even in principle.
-          # Tracked in #90 as follow-up work, not silently dropped.
+          # dagster_run_queue_concurrency_key_backlog and
+          # dagster_asset_last_materialization_status used to be excluded
+          # here (needed a run-queue backlog / a materialized asset that
+          # nothing created) — the "Trigger asset materialization and
+          # run-queue backlog conditions" step now creates both conditions.
+          #
+          # dagster_exporter_scrape_errors_total only appears once a scrape
+          # has failed, which a healthy e2e run never does — it can't be
+          # asserted present here even in principle, so it stays excluded.
           cat > /tmp/not-yet-asserted.txt <<'NAMES'
-          dagster_run_queue_concurrency_key_backlog
-          dagster_asset_last_materialization_status
           dagster_exporter_scrape_errors_total
           NAMES
           grep -vFxf /tmp/not-yet-asserted.txt /tmp/expected-metrics.txt > /tmp/expected-metrics-asserted.txt
@@ -88,6 +85,54 @@ jobs:
         run: |
           kubectl apply -f dev/kubernetes/dagster-deployment.yaml
           kubectl rollout status deployment/dagster --timeout=120s
+
+      # dagster_asset_last_materialization_status and
+      # dagster_run_queue_concurrency_key_backlog don't appear from just
+      # standing the fixtures up — see the two "needs" comments removed
+      # from the not-yet-asserted list below. Triggered here (against
+      # Dagster's own GraphQL, not the exporter) so the scrape+poll loop in
+      # the next-next step has the ~100s it already budgets to pick both up,
+      # rather than racing a trigger fired right before that poll starts.
+      - name: Trigger asset materialization and run-queue backlog conditions
+        run: |
+          kubectl port-forward svc/dagster 3000:3000 &
+          DAGSTER_PORT_FORWARD_PID=$!
+          for i in $(seq 1 10); do
+            curl -sf http://localhost:3000/server_info > /dev/null && break
+            sleep 1
+          done
+
+          # One launch per asset, not both in a single run: this metric is
+          # derived from the *run's* status (assetsLatestInfo.latestRun),
+          # not the individual asset's step (see docs/metrics.md) --
+          # materializing them together would make good_asset inherit
+          # bad_asset's failure, since one failing step fails the whole run.
+          # Verified locally: that's exactly what happened before this was
+          # split into two launches.
+          echo "--- materializing good_asset (dagster_asset_last_materialization_status needs a run, not just Definitions loading) ---"
+          curl -sf -X POST http://localhost:3000/graphql -H 'Content-Type: application/json' -d '{
+            "query": "mutation($e: ExecutionParams!) { launchPipelineExecution(executionParams: $e) { __typename ... on LaunchRunSuccess { run { runId status } } ... on PythonError { message } } }",
+            "variables": {"e": {"selector": {"repositoryLocationName": "dev-dagster-workspace", "repositoryName": "__repository__", "jobName": "__ASSET_JOB", "assetSelection": [{"path": ["good_asset"]}]}, "mode": "default"}}
+          }'
+          echo
+
+          echo "--- materializing bad_asset ---"
+          curl -sf -X POST http://localhost:3000/graphql -H 'Content-Type: application/json' -d '{
+            "query": "mutation($e: ExecutionParams!) { launchPipelineExecution(executionParams: $e) { __typename ... on LaunchRunSuccess { run { runId status } } ... on PythonError { message } } }",
+            "variables": {"e": {"selector": {"repositoryLocationName": "dev-dagster-workspace", "repositoryName": "__repository__", "jobName": "__ASSET_JOB", "assetSelection": [{"path": ["bad_asset"]}]}, "mode": "default"}}
+          }'
+          echo
+
+          echo "--- launching 3x heavy_job (concurrency_key=heavy_limit, limit 1 in dev/dagster_home/dagster.yaml -- 2 will queue) ---"
+          for i in 1 2 3; do
+            curl -sf -X POST http://localhost:3000/graphql -H 'Content-Type: application/json' -d '{
+              "query": "mutation($e: ExecutionParams!) { launchPipelineExecution(executionParams: $e) { __typename ... on LaunchRunSuccess { run { runId status } } ... on PythonError { message } } }",
+              "variables": {"e": {"selector": {"repositoryLocationName": "dev-dagster-workspace", "repositoryName": "__repository__", "jobName": "heavy_job"}, "mode": "default"}}
+            }'
+            echo
+          done
+
+          kill "$DAGSTER_PORT_FORWARD_PID"
 
       - name: Install the exporter chart
         run: |


### PR DESCRIPTION
## What

Adds a "Trigger asset materialization and run-queue backlog conditions" step to `helm-e2e.yml`, run against Dagster's own GraphQL right after the Dagster fixture is up (before installing the exporter chart, so the assertion step's existing ~100s scrape+poll budget isn't racing a just-fired trigger):

- Materializes `good_asset` and `bad_asset` as two **separate** `launchPipelineExecution` calls.
- Launches `heavy_job` three times against its `concurrency_key=heavy_limit` limit of 1 (`dev/dagster_home/dagster.yaml`), so two queue.

`dagster_run_queue_concurrency_key_backlog` and `dagster_asset_last_materialization_status` move from the "not yet asserted" list to the asserted set (20 of 21 families now asserted). Only `dagster_exporter_scrape_errors_total` stays excluded — it can't appear in a healthy e2e run by construction.

## Why

Both families were carved out in #99 because nothing in the e2e fixture created their conditions — tracked as the remaining scope of #90.

## QA

Verified against a real kind cluster end to end, not just checked for YAML validity — created the cluster, built and loaded both images, applied the Dagster fixture, and ran every new/changed step by hand:

```
--- materializing good_asset ---
{"data":{"launchPipelineExecution":{"__typename":"LaunchRunSuccess", ...}}}
--- materializing bad_asset ---
{"data":{"launchPipelineExecution":{"__typename":"LaunchRunSuccess", ...}}}
--- launching 3x heavy_job ---
{"data":{"launchPipelineExecution":{"__typename":"LaunchRunSuccess", ...}}}  x3
```

```
dagster_asset_last_materialization_status{asset_key="bad_asset",status="failure"} 1
dagster_asset_last_materialization_status{asset_key="good_asset",status="success"} 1
dagster_run_queue_concurrency_key_backlog{concurrency_key="heavy_limit"} 2
```

Caught a real issue in the process: the first attempt materialized `good_asset`+`bad_asset` in a **single** `launchPipelineExecution` (one asset job, both assets selected). That made `good_asset` incorrectly report `status="failure"` too — `dagster_asset_last_materialization_status` is derived from the *run's* status (`assetsLatestInfo.latestRun`), not the individual asset's step, so one failing step fails the whole run and every asset in it inherits that status. Confirmed this live against the cluster before splitting into two separate launches, then re-verified the fix produces the correct `good_asset=success` / `bad_asset=failure` split.

Also confirmed the extracted step scripts are syntactically valid bash (`bash -n`) and the workflow YAML parses correctly, per this repo's established habit of validating GitHub Actions heredoc/multiline scripts before pushing (`set -e`/pipefail interaction, YAML block scalar indentation).

Full family assertion after the fix, run against the same cluster:

```
all 20 asserted metric families are present
```

## Ref

Progresses #90 (all triggerable families now asserted; `dagster_exporter_scrape_errors_total` remains excluded by construction)