### PR TITLE
Split dbt deps into a uv dependency group; stop baking dagster_home into images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Both docker/exporter.Dockerfile and docker/dagster-dev.Dockerfile build
+# with `context: .` (docker-compose.yaml), and dagster-dev.Dockerfile does
+# `COPY dev/ dev/` -- without this file, that copies whatever local runtime
+# state happens to be sitting in dev/dagster_home (run history, event log
+# storage, the jaffle_shop DuckDB file) straight into the image. Caught by
+# accident: a "fresh" container built locally came up reporting materialized
+# assets from weeks of local dev/testing history baked into dev/dagster_home
+# from an earlier manual run. Mirrors the runtime-state entries in
+# .gitignore's "repository specific rules" section -- same reasoning, same
+# paths, different consumer (Docker's build context vs git's working tree).
+dev/dagster_home/.nux/
+dev/dagster_home/.telemetry/
+dev/dagster_home/history/
+dev/dagster_home/schedules/
+dev/dagster_home/storage/
+dev/dagster_home/logs/
+dev/dagster_home/jaffle_shop.duckdb
+dev/jaffle_shop/target/
+dev/jaffle_shop/logs/
+dev/jaffle_shop/.user.yml
+
+# Standard build-context bloat -- neither Dockerfile references these paths,
+# so excluding them only shrinks what gets sent to the Docker daemon.
+.git/
+.venv/
+__pycache__/
+.pytest_cache/
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ To see `dagster_code_location_load_error` actually report `1` (rather than trust
 ```sh
 # Stop the compose-managed dagster container first if it's running, then:
 docker compose run --rm --service-ports --name dagster-prometheus-exporter-dagster-1 dagster \
-  uv run dagster dev -w /app/dev/workspace.yaml -h 0.0.0.0 -p 3000
+  uv run --group dbt dagster dev -w /app/dev/workspace.yaml -h 0.0.0.0 -p 3000
 ```
 
 Then point the exporter at it (either `DAGSTER_GRAPHQL_ENDPOINT=http://localhost:3000/graphql` on the host, or `http://dagster-prometheus-exporter-dagster-1:3000/graphql` from another container on the same compose network) and check `/metrics` for:

--- a/docker/dagster-dev.Dockerfile
+++ b/docker/dagster-dev.Dockerfile
@@ -9,10 +9,24 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock README.md ./
 
-RUN uv sync --frozen --no-install-project
+# --group dbt: dagster-dbt/dbt-duckdb live in a separate uv dependency
+# group (not the base dependencies), so `uv sync` alone -- as used for
+# investigating GraphQL compatibility across Dagster versions (issue #67)
+# -- doesn't drag in dagster-dbt's own version pairing with dagster. This
+# image runs the actual dev stack, including the jaffle_shop dbt assets in
+# dev/dagster_workspace/definitions.py, so it needs the group installed.
+RUN uv sync --frozen --no-install-project --group dbt
 
 COPY dev/ dev/
 
 EXPOSE 3000
 
-CMD ["uv", "run", "dagster", "dev", "-h", "0.0.0.0", "-p", "3000"]
+# --group dbt again here, not just on the sync above: `uv run` does its own
+# implicit sync check, and while it doesn't re-prune the group in practice
+# (nothing invalidates the venv between build and container start), relying
+# on that implicitly would mean whether this container actually has
+# dagster-dbt depends on unstated uv sync-skip heuristics rather than
+# something declared in this file. Verified empirically: a bare `uv sync`
+# does prune the group back out (dagster-dbt is genuinely removed, not just
+# left stale), so this isn't a hypothetical concern.
+CMD ["uv", "run", "--group", "dbt", "dagster", "dev", "-h", "0.0.0.0", "-p", "3000"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,21 @@ requires-python = ">=3.13"
 dependencies = [
     "dagster>=1.13.15,<1.14",
     "dagster-webserver>=1.13.15,<1.14",
-    # Pinned exactly (not a range): dagster-dbt releases track the exact
-    # dagster patch they were built against 1:1 (0.29.15 <-> dagster
-    # 1.13.15), so a range here could pull in a dagster-dbt that demands a
-    # newer dagster than the one actually locked/verified (see issue #67).
+]
+
+[dependency-groups]
+# Kept out of [project.dependencies] deliberately: dagster-dbt releases
+# track the exact dagster patch they were built against 1:1 (0.29.15 <->
+# dagster 1.13.15, 0.28.22 <-> 1.12.22, ...), and even the dbt-core range
+# each one pulls in shifts between patches (verified: 0.28.0 requires
+# dbt-core<1.11, 0.28.22 requires dbt-core<1.12). Bundling that into the
+# base dependencies would mean every Dagster version investigated for
+# issue #67 also needs its own matching dagster-dbt/dbt-core resolution
+# before it can even be installed. `uv sync` (no flags) skips this group,
+# so the base dagster/dagster-webserver stack -- what #67 actually needs
+# to test GraphQL compatibility -- stays decoupled from it. Actually
+# running the jaffle_shop dev fixture needs `uv sync --group dbt`.
+dbt = [
     "dagster-dbt==0.29.15",
     "dbt-duckdb>=1.11,<1.12",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -291,16 +291,24 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
-    { name = "dagster-dbt" },
     { name = "dagster-webserver" },
+]
+
+[package.dev-dependencies]
+dbt = [
+    { name = "dagster-dbt" },
     { name = "dbt-duckdb" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "dagster", specifier = ">=1.13.15,<1.14" },
-    { name = "dagster-dbt", specifier = "==0.29.15" },
     { name = "dagster-webserver", specifier = ">=1.13.15,<1.14" },
+]
+
+[package.metadata.requires-dev]
+dbt = [
+    { name = "dagster-dbt", specifier = "==0.29.15" },
     { name = "dbt-duckdb", specifier = ">=1.11,<1.12" },
 ]
 


### PR DESCRIPTION
## What

Two related fixes, both surfaced while thinking through issue #67 (Dagster version compatibility) after #101 added `dagster-dbt`/`dbt-duckdb`:

1. **Move `dagster-dbt`/`dbt-duckdb` into a `[dependency-groups]` entry (`dbt`)** instead of `[project.dependencies]`. `uv sync` (no flags) now only installs `dagster`/`dagster-webserver`; `uv sync --group dbt` pulls in the dbt stack. Every `uv run` in the actual runtime path (`dagster-dev.Dockerfile`'s `CMD`, the manual `docker compose run` command in the README) now passes `--group dbt` explicitly rather than relying on the venv already having it from a prior sync.

2. **Add `.dockerignore`**, mirroring the runtime-state paths already excluded from git in `.gitignore`. `dagster-dev.Dockerfile`'s `COPY dev/ dev/` was baking whatever local `dev/dagster_home` state happened to exist (run history, event storage, the jaffle_shop DuckDB file) directly into the image.

## Why

**(1)** `dagster-dbt` releases pin an exact matching `dagster` patch 1:1 (`0.29.15` <-> `1.13.15`, `0.28.22` <-> `1.12.22`, ...), and even the `dbt-core` range each release accepts shifts between patches — verified: `dagster-dbt==0.28.0` requires `dbt-core<1.11`, `0.28.22` requires `dbt-core<1.12`, despite both being in the `1.12.x` line. Bundling it into the base dependencies would mean every candidate Dagster version investigated for #67 needs its own matching `dagster-dbt` version resolved before it can even install — a second, unrelated dimension of version pairing on top of the GraphQL compatibility question #67 is actually about. The dependency group decouples them.

**(2)** Found by accident verifying (1): a freshly built image, run as a brand-new container with no bind mount, came up reporting `customers`/`stg_customers`/`raw_customers` as `STALE` instead of `MISSING` — because the host's `dev/dagster_home/storage` had ~300 leftover run directories from local testing, all copied into the image at build time. `docker-compose`'s bind mount normally papers over this (overrides whatever got baked in), so it never surfaced there.

## QA

- `uv sync` (no group) → confirmed `dagster_dbt` import fails afterward (a real uninstall, not just "never installed").
- `uv sync --group dbt` → confirmed `dagster_dbt` importable.
- Confirmed `uv run` alone does *not* re-prune an already-synced `dbt` group (its implicit sync no-ops when nothing on disk changed) — but didn't rely on that implicit behavior for the actual dev-stack container; made it explicit instead.
- Rebuilt `docker/dagster-dev.Dockerfile`, ran it fresh, confirmed the jaffle_shop assets and `good_asset`/`bad_asset` still load and materialize correctly end to end.
- Rebuilt again after adding `.dockerignore`: confirmed the image no longer contains `dev/dagster_home/storage` at all, and a fresh container now correctly reports all five assets as `MISSING` (not `STALE`/leftover state).
- Confirmed `docker/exporter.Dockerfile` (same build context) is unaffected by the new `.dockerignore`.
- `go test ./...` unaffected (no Go changes).

## Ref

Follow-up to #101; relevant to #67