### PR TITLE
Spot-check Dagster 1.11.16/1.12.0/1.12.22/1.13.19 compatibility; add a verify-dagster-version-compat skill

### DIFF
--- a/.claude/skills/verify-dagster-version-compat/SKILL.md
+++ b/.claude/skills/verify-dagster-version-compat/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: verify-dagster-version-compat
+description: Check whether the exporter's GraphQL queries still work against a Dagster version other than the pinned/verified one (issue #67). Temporarily re-pins dagster/dagster-webserver/dagster-dbt to a candidate version, builds the dev image, and runs the same trigger-and-assert sequence as verify-metric against it. Use when investigating version compatibility, not for routine metric changes -- see verify-metric for that.
+---
+
+# Verify Dagster version compatibility
+
+`pyproject.toml`/`uv.lock` pin one Dagster version (currently `1.13.15`) as
+the only one actually verified. This checks a *different* candidate version
+the same way: real instance, real triggers, real `/metrics` output -- not
+just "does it install."
+
+Always test in the current git branch's working tree, uncommitted, and
+revert at the end (step 6). Never commit a version bump from this skill
+without deliberately deciding to move the pin.
+
+## 1. Find the matching dagster-dbt version
+
+`dagster-dbt` pins an *exact* matching `dagster` patch 1:1 (verified:
+`0.29.15` requires `dagster==1.13.15`, `0.28.22` requires `dagster==1.12.22`,
+same minor-offset pattern holds across the line). There is no range that
+works across multiple dagster patches -- look up the exact pairing:
+
+```sh
+curl -s "https://pypi.org/pypi/dagster-dbt/<candidate-dagster-dbt-version>/json" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['requires_dist'])"
+```
+
+**The `dbt-core` range that `dagster-dbt` accepts also shifts between
+patches within the same dagster minor line** -- don't assume it's fixed.
+Verified: `dagster-dbt==0.28.0` requires `dbt-core<1.11`, `0.28.22` requires
+`dbt-core<1.12`, despite both being in the `1.12.x` dagster line. Check each
+candidate's `requires_dist` for `dbt-core` too, and let `uv lock` resolve
+`dbt-duckdb` freely within it rather than hardcoding a range.
+
+## 2. Re-pin and lock
+
+Edit `pyproject.toml` directly (uncommitted):
+
+```toml
+dependencies = [
+    "dagster==<candidate>",
+    "dagster-webserver==<candidate>",
+]
+```
+
+and in `[dependency-groups].dbt`:
+
+```toml
+dbt = [
+    "dagster-dbt==<matching version from step 1>",
+    "dbt-duckdb>=<lower>,<<upper from step 1>",
+]
+```
+
+```sh
+uv lock
+```
+
+If this fails to resolve, that's itself a finding -- record which packages
+conflicted.
+
+## 3. Build and boot a standalone Dagster container
+
+```sh
+docker build -f docker/dagster-dev.Dockerfile -t dagster-dev-compat-test:<version> .
+docker network create compat-test-net
+docker run -d --rm --name dagster-compat-test --network compat-test-net dagster-dev-compat-test:<version>
+```
+
+**No `curl` inside this image** (`python:3.13-slim` base) -- `docker exec
+... curl` will fail with "executable file not found". Poll from a sidecar
+container on the same network instead:
+
+```sh
+for i in $(seq 1 15); do
+  docker run --rm --network compat-test-net curlimages/curl -sf http://dagster-compat-test:3000/server_info && break
+  sleep 3
+done
+```
+
+Startup can take longer than the usual dev stack (manifest.json is built
+fresh via `dbt parse` on first import, plus a colder image) -- 30-45s is not
+unusual, don't give up after the first few retries.
+
+Confirm the code location actually loaded (not just that the webserver is
+up):
+
+```sh
+docker run --rm --network compat-test-net curlimages/curl -s -X POST http://dagster-compat-test:3000/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ workspaceOrError { __typename ... on Workspace { locationEntries { name loadStatus locationOrLoadError { __typename ... on PythonError { message } } } } } }"}'
+```
+
+`loadStatus: "LOADED"` with `locationOrLoadError.__typename:
+"RepositoryLocation"` means clean. A `PythonError` here is itself a
+compatibility finding (e.g. a GraphQL/Python API the fixture code relies on
+no longer exists in this version) -- capture the message.
+
+## 4. Run the exporter against it and trigger conditions
+
+```sh
+docker run -d --rm --name exporter-compat-test --network compat-test-net -p 9103:9101 \
+  -e DAGSTER_GRAPHQL_ENDPOINT=http://dagster-compat-test:3000/graphql \
+  dagster-prometheus-exporter-exporter   # reuse the image already built by docker compose
+curl -s http://127.0.0.1:9103/readyz     # should report the candidate version
+```
+
+Same trigger set as `verify-metric`'s e2e equivalent, run once:
+
+```sh
+docker exec dagster-compat-test uv run --group dbt dagster asset materialize -m dev.dagster_workspace.definitions --select 'good_asset'
+
+docker run --rm --network compat-test-net curlimages/curl -s -X POST http://dagster-compat-test:3000/graphql \
+  -H 'Content-Type: application/json' -d '{
+  "query": "mutation($e: ExecutionParams!) { launchPipelineExecution(executionParams: $e) { __typename ... on LaunchRunSuccess { run { runId status } } ... on PythonError { message } } }",
+  "variables": {"e": {"selector": {"repositoryLocationName": "dev-dagster-workspace", "repositoryName": "__repository__", "jobName": "quick_job"}, "mode": "default"}}
+}'
+# heavy_job x3 (concurrency_key=heavy_limit, limit 1 -- produces a backlog)
+for i in 1 2 3; do
+  docker run --rm --network compat-test-net curlimages/curl -s -X POST http://dagster-compat-test:3000/graphql \
+    -H 'Content-Type: application/json' -d '{
+    "query": "mutation($e: ExecutionParams!) { launchPipelineExecution(executionParams: $e) { __typename ... on LaunchRunSuccess { run { runId status } } ... on PythonError { message } } }",
+    "variables": {"e": {"selector": {"repositoryLocationName": "dev-dagster-workspace", "repositoryName": "__repository__", "jobName": "heavy_job"}, "mode": "default"}}
+  }'
+done
+```
+
+## 5. Assert every metric family, and spot-check the fragile ones
+
+```sh
+go test -run TestListMetricNames -v ./internal/server/... \
+  | grep '^METRIC:' | sed 's/^METRIC: //' | sort > /tmp/expected-metrics-compat.txt
+
+# poll until stable (up to ~45s)
+for i in $(seq 1 20); do
+  M=$(curl -s http://127.0.0.1:9103/metrics)
+  echo "$M" | grep -q "dagster_last_run_info" && break
+  sleep 3
+done
+MISSING=""
+while read -r name; do
+  echo "$M" | grep -q "^${name}{" || MISSING="$MISSING $name"
+done < /tmp/expected-metrics-compat.txt
+echo "missing (only dagster_exporter_scrape_errors_total expected):$MISSING"
+```
+
+Then read the actual label values on the historically fragile ones -- a
+family being *present* doesn't mean the query behaves correctly (`#69`,
+`#85` were both "present but wrong" bugs):
+
+```sh
+echo "$M" | grep -E "^dagster_daemon_healthy|^dagster_schedule_last_tick_status|^dagster_sensor_last_tick_status|^dagster_asset_stale_status|^dagster_code_location_load_error"
+```
+
+Check specifically: all 6 daemon types present (not fewer -- a version
+might rename/add/remove a daemon type), all 3 distinct tick statuses
+(success/skipped/failure) actually showing, stale status resolving without
+error.
+
+## 6. Revert -- do not leave the version bump in place
+
+```sh
+git checkout -- pyproject.toml uv.lock
+uv sync --group dbt   # restore local dev venv to the pinned version
+docker rm -f dagster-compat-test exporter-compat-test
+docker network rm compat-test-net
+docker rmi dagster-dev-compat-test:<version>
+rm -f /tmp/expected-metrics-compat.txt
+```
+
+## Recording the result
+
+Note the candidate version, whether it resolved/built/loaded/passed, and
+the daemon-type list actually observed (Dagster has added daemon types
+before -- if the list differs from `1.13.15`'s six, that's worth flagging
+even if nothing broke). If something failed, the specific GraphQL error or
+missing metric family *is* the actionable finding for issue #67 -- record
+it verbatim rather than summarizing it away.

--- a/.claude/skills/verify-dagster-version-compat/SKILL.md
+++ b/.claude/skills/verify-dagster-version-compat/SKILL.md
@@ -158,6 +158,15 @@ might rename/add/remove a daemon type), all 3 distinct tick statuses
 (success/skipped/failure) actually showing, stale status resolving without
 error.
 
+This has already found a real, benign difference: `1.11.16` reports only 5
+daemon types, missing `FRESHNESS_DAEMON` (introduced sometime in the
+`1.12.0` cycle). Confirmed via the raw `instance.daemonHealth` query, not
+assumed -- it's Dagster itself not reporting that daemon type on `1.11.16`,
+not an exporter bug (the collector's daemon-health loop has no hardcoded
+expected list, so it already handles this correctly). Still worth recording
+in `docs/metrics.md` and the issue, since a user on an older version
+shouldn't read a missing row as broken.
+
 ## 6. Revert -- do not leave the version bump in place
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker compose up --build
 
 Pinned against Dagster **1.13.15** (`pyproject.toml`/`uv.lock`, for the local dev stack) — this is the version every metric here has actually been verified against. Dagster's GraphQL API isn't a stable, versioned contract — fields and types can change between releases — so this exporter isn't guaranteed to work against significantly older or newer Dagster versions in general.
 
-That said, spot-checks against **1.12.0** and **1.13.19** (real instance, every metric family asserted, not just "does it install") found no incompatibilities — see [issue #67](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/67) for what was checked. Versions between these three are more likely than not to work too, but haven't been individually verified. If you hit a GraphQL error running against a different version, please [open an issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose).
+That said, spot-checks against **1.11.16, 1.12.0, 1.12.22, and 1.13.19** (real instance, every metric family asserted, not just "does it install") found no incompatibilities — see [issue #67](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/67) for what was checked, including one benign cross-version difference in `dagster_daemon_healthy` (see [docs/metrics.md](docs/metrics.md)). Versions between these are more likely than not to work too, but haven't been individually verified. If you hit a GraphQL error running against a different version, please [open an issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose).
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ docker compose up --build
 
 ## Compatibility
 
-Tested against Dagster **1.13.15** (the version pinned in `pyproject.toml`/`uv.lock` for the local dev stack). Dagster's GraphQL API isn't a stable, versioned contract — fields and types can change between releases — so this exporter isn't guaranteed to work against significantly older or newer Dagster versions. If you hit a GraphQL error running against a different version, please [open an issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose).
+Pinned against Dagster **1.13.15** (`pyproject.toml`/`uv.lock`, for the local dev stack) — this is the version every metric here has actually been verified against. Dagster's GraphQL API isn't a stable, versioned contract — fields and types can change between releases — so this exporter isn't guaranteed to work against significantly older or newer Dagster versions in general.
+
+That said, spot-checks against **1.12.0** and **1.13.19** (real instance, every metric family asserted, not just "does it install") found no incompatibilities — see [issue #67](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/67) for what was checked. Versions between these three are more likely than not to work too, but haven't been individually verified. If you hit a GraphQL error running against a different version, please [open an issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose).
 
 ## Motivation
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,7 +54,7 @@ A code location can fail to load independently of any job/run activity — `dags
 
 Labels: `daemon_type`, `required`
 
-`1` if the daemon is currently healthy, `0` otherwise. `daemon_type` is one of Dagster's daemons — on 1.13.15: `SCHEDULER`, `SENSOR`, `BACKFILL`, `QUEUED_RUN_COORDINATOR`, `ASSET`, `FRESHNESS_DAEMON`.
+`1` if the daemon is currently healthy, `0` otherwise. `daemon_type` is one of Dagster's daemons — on 1.13.15: `SCHEDULER`, `SENSOR`, `BACKFILL`, `QUEUED_RUN_COORDINATOR`, `ASSET`, `FRESHNESS_DAEMON`. This list isn't hardcoded here — the collector reports whatever `instance.daemonHealth.allDaemonStatuses` returns, so it varies by Dagster version: verified `FRESHNESS_DAEMON` doesn't exist at all on 1.11.16 (only 5 daemon types), appearing sometime in the 1.12.0 cycle ([#67](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/67)). Don't read a missing `FRESHNESS_DAEMON` row as broken on an older Dagster version.
 
 This is the only metric here that reports on Dagster's machinery rather than its work, and it answers a question none of the others can: **is the scheduler actually running?** When the daemon dies, everything else keeps looking healthy — `dagster_schedule_status` still reports `running` (the schedule *is* enabled; that metric is about the on/off state, not the daemon), the last tick status stays frozen at whatever it was, active runs simply go quiet, and `dagster_exporter_last_scrape_success` stays `1` because the GraphQL endpoint is served by the webserver, which is fine. Nothing changes. Without this metric, "the scheduler is dead" and "nothing was scheduled" are indistinguishable.
 


### PR DESCRIPTION
## What

Adds `.claude/skills/verify-dagster-version-compat/SKILL.md`, encoding the procedure used to check the exporter's GraphQL queries against a Dagster version other than the pinned/verified `1.13.15`: find the matching `dagster-dbt`/`dbt-core` pair, re-pin and lock, build the dev image, boot it standalone, trigger the same conditions `verify-metric` uses, assert every metric family, and spot-check the historically fragile ones (daemon types, tick statuses, staleness).

Also updates the README's Compatibility section and `docs/metrics.md` with what was found.

## Why

Issue #67 (investigate compatibility across Dagster versions) — this is the first real data beyond the single pinned version. The original plan there was manual spot-checks before considering any CI automation, since it wasn't known yet whether anything actually breaks across versions.

## QA

Checked four versions spanning and bracketing the current pin (real instance each time, not just "does it install"): `1.11.16` (latest 1.11.x), `1.12.0`, `1.12.22` (latest 1.12.x), `1.13.19` (current latest).

- Code location loads cleanly on all four (`workspaceOrError` → `LOADED`, no `PythonError`)
- All 20 metric families that can appear without a rare trigger present on all four, using the same trigger set `helm-e2e.yml` uses (materialize `good_asset`, launch `quick_job` once, launch `heavy_job` 3x for the concurrency backlog)
- Spot-checked the families with a history of being present-but-wrong (#69, #85): tick status shows all 3 distinct values (success/skipped/failure), `dagster_asset_stale_status`/`dagster_code_location_load_error` resolve cleanly, on all four

**Result: all four fully compatible.** One real, benign difference found: `dagster_daemon_healthy` reports only **5** daemon types on `1.11.16`, missing `FRESHNESS_DAEMON`. Confirmed via the raw `instance.daemonHealth.allDaemonStatuses` query that Dagster itself doesn't report that daemon type on `1.11.16` — not an exporter bug, it was introduced sometime in the `1.12.0` cycle. The collector's daemon-health loop (`internal/collector/daemon_health.go`) has no hardcoded expected daemon list, so this was already handled correctly by design; documented in `docs/metrics.md` so a user on an older version doesn't mistake a missing row for something broken.

Also documented in the skill:
- `dagster-dbt`'s `dbt-core` version range isn't fixed within one dagster minor line — `dagster-dbt==0.28.0` (dagster `1.12.0`) requires `dbt-core<1.11`, but `0.28.22` (dagster `1.12.22`) requires `dbt-core<1.12`. Has to be re-checked per candidate version, not assumed from a prior lock.
- `docker/dagster-dev.Dockerfile`'s image has no `curl` (`python:3.13-slim` base) — `docker exec ... curl` fails outright, use a `curlimages/curl` sidecar container on the same Docker network instead.

`pyproject.toml`/`uv.lock` are back on the pinned `1.13.15` after every candidate check (reverted via `git checkout`, confirmed clean before each commit).

## Ref

Progresses #67 (4 versions spot-checked, not yet a matrix; findings also posted to the issue)