### PR TITLE
Turn the compatibility spot-check list into a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,17 @@ docker compose up --build
 
 Pinned against Dagster **1.13.15** (`pyproject.toml`/`uv.lock`, for the local dev stack) — this is the version every metric here has actually been verified against. Dagster's GraphQL API isn't a stable, versioned contract — fields and types can change between releases — so this exporter isn't guaranteed to work against significantly older or newer Dagster versions in general.
 
-That said, spot-checks against **1.11.16, 1.12.0, 1.12.22, and 1.13.19** (real instance, every metric family asserted, not just "does it install") found no incompatibilities — see [issue #67](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/67) for what was checked, including one benign cross-version difference in `dagster_daemon_healthy` (see [docs/metrics.md](docs/metrics.md)). Versions between these are more likely than not to work too, but haven't been individually verified. If you hit a GraphQL error running against a different version, please [open an issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose).
+That said, a few other versions have been spot-checked against a real instance (every metric family asserted, not just "does it install" — see [issue #67](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/67) for the procedure):
+
+| Dagster version | Result |
+| --- | --- |
+| 1.11.16 | ✅ Compatible — `dagster_daemon_healthy` reports 5 daemon types, not 6 (`FRESHNESS_DAEMON` doesn't exist yet; see [docs/metrics.md](docs/metrics.md)) |
+| 1.12.0 | ✅ Compatible |
+| 1.12.22 | ✅ Compatible |
+| **1.13.15** | ✅ Compatible — the pinned/CI version |
+| 1.13.19 | ✅ Compatible |
+
+Versions between these are more likely than not to work too, but haven't been individually verified. If you hit a GraphQL error running against a different version, please [open an issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose).
 
 ## Motivation
 


### PR DESCRIPTION
## What

Converts the Compatibility section's spot-checked-versions sentence into a table.

## Why

The prose form was already hard to scan with 4 versions listed and will only grow as issue #67 adds more. A table also gives each entry a natural place for a per-version caveat (like 1.11.16's missing `FRESHNESS_DAEMON`) without cluttering a sentence.

## QA

Docs-only change, rendered the table locally to confirm it's well-formed markdown.

## Ref

Follow-up to #104