### PR TITLE
Add SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Reporting bugs / requesting features
 
-Open a [GitHub issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose) using the appropriate template.
+Open a [GitHub issue](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/new/choose) using the appropriate template. For a security vulnerability, see [SECURITY.md](SECURITY.md) instead — don't file a public issue.
 
 ## Submitting a pull request
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report it privately via [GitHub Security Advisories](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/security/advisories/new) rather than a public issue. There's no dedicated security email — this is a solo-maintained project, and the private advisory flow already routes reports only to the maintainer.
+
+Include what you'd include in a normal bug report — steps to reproduce, affected version/commit, and what the actual impact is — plus anything specific to why it's a security issue rather than a correctness one.
+
+## Response
+
+Best-effort, not an SLA. This is maintained by one person outside of paid work, not a company with a security team. If you don't hear back within a reasonable time, a follow-up comment on the advisory is welcome.
+
+## Supported versions
+
+Only the latest released version (`v*` tag / `latest` Docker/Helm tag) is supported. There's no LTS or backport policy — fixes land on `main` and go out in the next release.
+
+## Scope
+
+This exporter reads from Dagster's GraphQL API (`DAGSTER_GRAPHQL_ENDPOINT`) and exposes a `/metrics` endpoint; it doesn't hold credentials beyond that endpoint URL and doesn't write to Dagster. Reports involving how it's deployed (e.g. the Helm chart's default RBAC/network exposure) are in scope alongside the Go binary itself.


### PR DESCRIPTION
## What

Adds `SECURITY.md`: how to report a vulnerability (private GitHub Security Advisory, not a public issue), an honest best-effort response expectation, the only-latest-release support policy, and scope (this exporter reads Dagster's GraphQL API and holds no credentials beyond the endpoint URL; Helm chart deployment concerns are in scope too).

Also points `CONTRIBUTING.md`'s bug-report section at it.

## Why

No vulnerability-reporting policy existed. Not just generic hygiene — this exporter is configured with `DAGSTER_GRAPHQL_ENDPOINT` and polls a user's Dagster instance continuously, so a real report deserves a documented path.

## QA

Docs-only change.

## Ref

Closes #106