### PR TITLE
Bump chart to 0.1.5, appVersion to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Or deploy to Kubernetes with the [Helm chart](charts/dagster-prometheus-exporter
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.4 \
+  --version 0.1.5 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 

--- a/charts/dagster-prometheus-exporter/Chart.yaml
+++ b/charts/dagster-prometheus-exporter/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: dagster-prometheus-exporter
 description: A Prometheus exporter for Dagster run metrics
 type: application
-version: 0.1.4
+version: 0.1.5
 # Must exactly match a real tag on ghcr.io/hirofumitsuda/dagster-prometheus-exporter
 # (no "v" prefix — docker/metadata-action's {{version}} pattern in
 # docker-publish.yml strips it from the git tag when publishing), since
 # templates/deployment.yaml defaults image.tag to this value.
-appVersion: "0.3.0"
+appVersion: "0.4.0"
 home: https://github.com/HirofumiTsuda/dagster-prometheus-exporter
 sources:
   - https://github.com/HirofumiTsuda/dagster-prometheus-exporter

--- a/charts/dagster-prometheus-exporter/README.md
+++ b/charts/dagster-prometheus-exporter/README.md
@@ -8,7 +8,7 @@ The chart is published as an OCI artifact to GHCR:
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.4 \
+  --version 0.1.5 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 


### PR DESCRIPTION
## What

Bumps `Chart.yaml`'s `version` to `0.1.5` and `appVersion` to `0.4.0`, and the two `--version 0.1.4` install examples (README.md, chart README) to `0.1.5`.

## Why

`v0.4.0` (asset materialization/staleness metrics, #56) is already tagged and published — following the established release order (app tag → image published → chart bump → chart tag), since `helm-lint.yml` verifies the chart's default-rendered image actually exists on GHCR, and bumping `appVersion` before the image exists always fails that check.

## QA

- `docker pull ghcr.io/hirofumitsuda/dagster-prometheus-exporter:0.4.0` — succeeds, `dagster_exporter_build_info{commit="5e60072...",version="v0.4.0"}` matches `main` HEAD
- `helm lint --strict charts/dagster-prometheus-exporter` — passes
- `helm template charts/dagster-prometheus-exporter` — default image resolves to `ghcr.io/hirofumitsuda/dagster-prometheus-exporter:0.4.0`, the real published tag

## Ref

Part of the v0.4.0 / chart-v0.1.5 release