### PR TITLE
add nodeSelector, tolerations, and affinity to the chart

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -59,4 +59,7 @@ jobs:
         run: |
           helm template charts/dagster-prometheus-exporter \
             --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql \
-            --set serviceMonitor.enabled=true
+            --set serviceMonitor.enabled=true \
+            --set nodeSelector."kubernetes\.io/os"=linux \
+            --set-json 'tolerations=[{"key":"dedicated","operator":"Equal","value":"monitoring","effect":"NoSchedule"}]' \
+            --set-json 'affinity={"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/arch","operator":"In","values":["amd64"]}]}]}}}'

--- a/charts/dagster-prometheus-exporter/README.md
+++ b/charts/dagster-prometheus-exporter/README.md
@@ -34,8 +34,12 @@ helm install my-dagster-exporter ./dagster-prometheus-exporter/charts/dagster-pr
 | `env` | `{}` | Environment variables passed to the exporter via a ConfigMap (`envFrom`). Keys match `internal/config/config.go` exactly. |
 | `resources` | `{}` | Standard pod resource requests/limits. |
 | `podAnnotations` / `podLabels` | `{}` | Extra pod metadata. |
+| `nodeSelector` | `{}` | Node labels the pod must match to be scheduled. |
+| `tolerations` | `[]` | Taints the pod tolerates — e.g. for a dedicated monitoring node pool. |
+| `affinity` | `{}` | Node/pod affinity and anti-affinity rules. |
 | `serviceMonitor.enabled` | `false` | Create a prometheus-operator `ServiceMonitor`. Requires the CRD to already be installed. |
 | `serviceMonitor.interval` | `30s` | Scrape interval for the `ServiceMonitor`. |
+| `serviceMonitor.additionalLabels` | `{}` | Extra labels on the `ServiceMonitor`, for matching a Prometheus instance's `serviceMonitorSelector`. |
 | `nameOverride` / `fullnameOverride` | `""` | Override the chart's computed resource name. |
 
 ## Notes

--- a/charts/dagster-prometheus-exporter/templates/deployment.yaml
+++ b/charts/dagster-prometheus-exporter/templates/deployment.yaml
@@ -46,3 +46,15 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/dagster-prometheus-exporter/values.yaml
+++ b/charts/dagster-prometheus-exporter/values.yaml
@@ -41,6 +41,10 @@ resources: {}
 podAnnotations: {}
 podLabels: {}
 
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
 # For prometheus-operator setups. Requires the ServiceMonitor CRD to already
 # be installed in the cluster.
 serviceMonitor:


### PR DESCRIPTION
## What

Add `nodeSelector`, `tolerations`, and `affinity` to the chart, rendered in the Deployment pod spec and defaulting to empty. Document them (plus the existing `serviceMonitor.additionalLabels`) in the chart README.

## Why

The chart had no way to pin the exporter to a specific node pool — a common need when monitoring workloads run on dedicated, tainted nodes. Values-only change; existing installs render identically.

## QA

`helm-lint.yml` now templates the chart with all three fields set (including a `NoSchedule` toleration and a `kubernetes.io/arch` node affinity) so the new blocks are exercised in CI.

## Ref

N/A
