### PR TITLE
Document the concurrency-key cardinality assumption

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -99,6 +99,8 @@ Note: Dagster's `instance.concurrencyLimits` GraphQL query looks like it would a
 
 A concurrency key is zero-filled (not dropped) once its backlog clears, for the same reason as `dagster_active_runs`: a missing series and a `0` mean different things.
 
+This assumes the set of concurrency keys is bounded and small, since a key is zero-filled forever once observed — there's no roster query to prune against (unlike jobs), and nothing currently expires one. That holds for the common case of `tag_concurrency_limits` naming a handful of fixed tag values (e.g. specific `team` or `warehouse` values). It does **not** hold for a limit declared with `applyLimitPerUniqueValue: true` against a high-cardinality tag (a tenant id, a customer id, a date) — every distinct value seen becomes a permanent series until the exporter restarts. See [#81](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/81) if that's your setup.
+
 ## `dagster_schedule_status` (Gauge)
 
 Labels: `schedule_name`, `location`, `status`

--- a/internal/collector/active_runs.go
+++ b/internal/collector/active_runs.go
@@ -107,6 +107,13 @@ func CollectActiveRuns(ctx context.Context, c *DagsterCollector) error {
 	// "this key has never been seen." There's no upfront list of
 	// configured concurrency keys to seed from (unlike knownJobs), so
 	// "every key ever observed" is the best available substitute.
+	//
+	// This assumes the key set stays small and bounded -- nothing ever
+	// expires an entry, so a high-cardinality key (applyLimitPerUniqueValue
+	// against a tenant/customer/date-like tag) would grow this map, and the
+	// metric's series count, without bound for the life of the process.
+	// See docs/metrics.md and
+	// https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/81.
 	for key := range c.concurrencyKeyBacklog {
 		if _, ok := backlog[key]; !ok {
 			backlog[key] = 0


### PR DESCRIPTION
## What

Documents, in both `docs/metrics.md` and a code comment on `CollectActiveRuns`, that `dagster_run_queue_concurrency_key_backlog`'s zero-fill assumes a bounded, small set of concurrency keys — nothing currently expires a key once observed, so a limit declared with `applyLimitPerUniqueValue: true` against a high-cardinality tag (tenant id, customer id, date-like value) would grow the series count without bound for the life of the process.

## Why

Per #81's own analysis: the growth is real but conditional on a configuration this project has never seen in use, and every mitigation (capping, expiring by age, dropping persistence) trades away the zero-fill's actual signal — "0" vs. "never seen" — to solve a problem nobody has reported. Writing the assumption down explicitly (rather than leaving it as an unexamined "grows forever") is the cheapest option and the one #81 itself recommends trying first, revisiting with an actual bound only if someone reports hitting it.

## QA

Docs-only plus a comment change; no behavior change. Confirmed the package still builds (`go build ./...`).

## Ref

Closes #81