### PR TITLE
Add dagster_asset_last_materialization_timestamp_seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Full label reference, edge cases, and design rationale for every metric below: [
 | `dagster_sensor_last_tick_timestamp_seconds` | Gauge | When a sensor last ticked, so a stalled evaluation loop is detectable. |
 | `dagster_asset_stale_status` | Gauge | Whether an asset's data is missing, stale, or fresh. |
 | `dagster_asset_last_materialization_status` | Gauge | Outcome of an asset's most recently launched materializing run — the only one of the two that shows a failed run, since staleness alone can't tell "failed" from "never run". |
+| `dagster_asset_last_materialization_timestamp_seconds` | Gauge | When an asset was last materialized, regardless of outcome — catches a leaf asset that's gone quiet, since stale status alone can't (it's a `code_version` comparison, not elapsed time). |
 
 ### Exporter self-health
 
@@ -159,6 +160,9 @@ dagster_asset_stale_status{asset_key="bad_asset",status="missing"} 1
 
 dagster_asset_last_materialization_status{asset_key="good_asset",status="success"} 1
 dagster_asset_last_materialization_status{asset_key="bad_asset",status="failure"} 1
+
+dagster_asset_last_materialization_timestamp_seconds{asset_key="good_asset"} 1.788674981623458e+09
+dagster_asset_last_materialization_timestamp_seconds{asset_key="bad_asset"} 1.788674993059941e+09
 ```
 
 ### PromQL examples

--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -938,6 +938,29 @@
         "x": 12,
         "y": 69
       }
+    },
+    {
+      "title": "Asset Materialization Age",
+      "description": "Seconds since each asset was last materialized, regardless of outcome. Unlike Asset Stale Status (a code_version comparison to an upstream), this catches a leaf/source asset that has simply gone quiet.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "time() - dagster_asset_last_materialization_timestamp_seconds",
+          "legendFormat": "{{asset_key}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 77
+      }
     }
   ],
   "templating": {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -163,6 +163,16 @@ Always `1`; status of an asset's most recently launched materializing run (`asse
 
 This exists because `dagster_asset_stale_status` can't answer "did the last run succeed": `assetMaterializations` (and the `staleStatus` derived from it) only records successful events, so a failing asset and one that has simply never run both look `missing` there. This metric reads the run itself instead, so a failed run is visible even though it left the asset's materialization history untouched.
 
+## `dagster_asset_last_materialization_timestamp_seconds` (Gauge)
+
+Labels: `asset_key`
+
+Unix timestamp (`assetsLatestInfo.latestRun.endTime`) of an asset's most recent materializing run, regardless of whether it succeeded. Exported as a timestamp rather than an age so staleness is computed at query time (`time() - metric`) instead of being frozen at scrape time — the same reasoning as `dagster_daemon_last_heartbeat_timestamp_seconds` and the schedule/sensor tick timestamps. Tracks the same run as `dagster_asset_last_materialization_status` (same lifetime), so an asset that has never had a run has no series for either.
+
+This exists because `dagster_asset_stale_status` only detects staleness *relative to an upstream* (a `code_version` comparison, not elapsed time) — a leaf/source asset with no upstream dependency reports `fresh` forever once materialized once, even if it hasn't actually run again in months. This metric is what makes "this asset hasn't been materialized recently" alertable on its own, the same gap [#84](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/84) closed for schedules and sensors.
+
+`endTime`, not `updateTime`, to match the existing convention: `dagster_last_run_duration_seconds` already uses `endTime - creationTime` for completed jobs, so this stays consistent with how "when did this run finish" is computed elsewhere in the codebase.
+
 ## Exporter self-health
 
 These report on the exporter itself, rather than on Dagster's run state. The first three are about whether its own scrapes of Dagster are succeeding, and are labeled `collector`, one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status`, `daemon_health`, or `asset_status` (the six concurrent collectors described in [docs/architecture.md](architecture.md)).

--- a/internal/collector/asset_status.go
+++ b/internal/collector/asset_status.go
@@ -17,6 +17,11 @@ type assetStatusEntry struct {
 	// lastMaterializationStatus is "" when the asset has never had a run —
 	// no dagster_asset_last_materialization_status series is emitted for it.
 	lastMaterializationStatus string
+	// lastMaterializationTimestamp is only meaningful when
+	// lastMaterializationStatus is set -- both come from the same non-nil
+	// LatestRun, so reflectAssetStatus gates emitting it on that field
+	// rather than a dedicated has-value flag.
+	lastMaterializationTimestamp float64
 }
 
 // CollectAssetStatus reports each asset's staleness and the outcome of its
@@ -73,6 +78,7 @@ func CollectAssetStatus(ctx context.Context, c *DagsterCollector) error {
 			key := assetKeyLabel(info.AssetKey.Path)
 			entry := entries[key]
 			entry.lastMaterializationStatus = info.LatestRun.Status
+			entry.lastMaterializationTimestamp = info.LatestRun.EndTime
 			entries[key] = entry
 		}
 	}
@@ -93,10 +99,11 @@ func assetKeyLabel(path AssetKeyPath) string {
 	return strings.Join(path, "/")
 }
 
-// reflectAssetStatus emits dagster_asset_stale_status and
-// dagster_asset_last_materialization_status from a single locked pass over
-// c.assetStatus, the same reasoning as reflectDaemonHealth: both come from
-// one entry per asset.
+// reflectAssetStatus emits dagster_asset_stale_status,
+// dagster_asset_last_materialization_status, and
+// dagster_asset_last_materialization_timestamp_seconds from a single locked
+// pass over c.assetStatus, the same reasoning as reflectDaemonHealth: all
+// three come from one entry per asset.
 func reflectAssetStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -119,6 +126,12 @@ func reflectAssetStatus(c *DagsterCollector, ch chan<- prometheus.Metric) {
 				1,
 				assetKey,
 				strings.ToLower(entry.lastMaterializationStatus),
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.assetLastMaterializationTimestampDesc,
+				prometheus.GaugeValue,
+				entry.lastMaterializationTimestamp,
+				assetKey,
 			)
 		}
 	}

--- a/internal/collector/asset_status_test.go
+++ b/internal/collector/asset_status_test.go
@@ -61,8 +61,8 @@ func TestCollectAssetStatusDistinguishesNeverRunFromFailed(t *testing.T) {
 	latestInfoBody := `{
 		"data": {
 			"assetsLatestInfo": [
-				{"assetKey": {"path": ["good_asset"]}, "latestRun": {"status": "SUCCESS"}},
-				{"assetKey": {"path": ["bad_asset"]}, "latestRun": {"status": "FAILURE"}},
+				{"assetKey": {"path": ["good_asset"]}, "latestRun": {"status": "SUCCESS", "endTime": 1700000100}},
+				{"assetKey": {"path": ["bad_asset"]}, "latestRun": {"status": "FAILURE", "endTime": 1700000200}},
 				{"assetKey": {"path": ["never_run_asset"]}, "latestRun": null}
 			]
 		}
@@ -73,8 +73,8 @@ func TestCollectAssetStatusDistinguishesNeverRunFromFailed(t *testing.T) {
 	require.NoError(t, CollectAssetStatus(t.Context(), c))
 
 	require.Len(t, c.assetStatus, 3)
-	assert.Equal(t, assetStatusEntry{staleStatus: "FRESH", lastMaterializationStatus: "SUCCESS"}, c.assetStatus["good_asset"])
-	assert.Equal(t, assetStatusEntry{staleStatus: "MISSING", lastMaterializationStatus: "FAILURE"}, c.assetStatus["bad_asset"],
+	assert.Equal(t, assetStatusEntry{staleStatus: "FRESH", lastMaterializationStatus: "SUCCESS", lastMaterializationTimestamp: 1700000100}, c.assetStatus["good_asset"])
+	assert.Equal(t, assetStatusEntry{staleStatus: "MISSING", lastMaterializationStatus: "FAILURE", lastMaterializationTimestamp: 1700000200}, c.assetStatus["bad_asset"],
 		"a failed run must be distinguishable from an asset that has never run, even though both look MISSING via staleStatus alone")
 	assert.Equal(t, assetStatusEntry{staleStatus: "MISSING", lastMaterializationStatus: ""}, c.assetStatus["never_run_asset"])
 }
@@ -178,11 +178,11 @@ func TestCollectAssetStatusReturnsErrorOnGraphQLError(t *testing.T) {
 func TestReflectAssetStatus(t *testing.T) {
 	c := NewDagsterCollector(t.Context(), "http://unused", time.Hour, time.Hour, 500, 5*time.Minute)
 	c.assetStatus = map[string]assetStatusEntry{
-		"good_asset":      {staleStatus: "FRESH", lastMaterializationStatus: "SUCCESS"},
+		"good_asset":      {staleStatus: "FRESH", lastMaterializationStatus: "SUCCESS", lastMaterializationTimestamp: 1700000100},
 		"never_run_asset": {staleStatus: "MISSING", lastMaterializationStatus: ""},
 	}
 
-	ch := make(chan prometheus.Metric, 8)
+	ch := make(chan prometheus.Metric, 16)
 	go func() {
 		reflectAssetStatus(c, ch)
 		close(ch)
@@ -205,6 +205,8 @@ func TestReflectAssetStatus(t *testing.T) {
 			metricName = "dagster_asset_stale_status"
 		case strings.Contains(desc, "dagster_asset_last_materialization_status"):
 			metricName = "dagster_asset_last_materialization_status"
+		case strings.Contains(desc, "dagster_asset_last_materialization_timestamp_seconds"):
+			metricName = "dagster_asset_last_materialization_timestamp_seconds"
 		default:
 			t.Fatalf("unexpected metric desc: %s", desc)
 		}
@@ -223,7 +225,8 @@ func TestReflectAssetStatus(t *testing.T) {
 
 	assert.Equal(t, float64(1), seen[key{"dagster_asset_stale_status", "good_asset", "fresh"}])
 	assert.Equal(t, float64(1), seen[key{"dagster_asset_last_materialization_status", "good_asset", "success"}])
+	assert.Equal(t, float64(1700000100), seen[key{"dagster_asset_last_materialization_timestamp_seconds", "good_asset", ""}])
 	assert.Equal(t, float64(1), seen[key{"dagster_asset_stale_status", "never_run_asset", "missing"}])
-	assert.Len(t, seen, 3,
-		"never_run_asset must not emit a dagster_asset_last_materialization_status series: it has no run to report a status for")
+	assert.Len(t, seen, 4,
+		"never_run_asset must not emit dagster_asset_last_materialization_status or dagster_asset_last_materialization_timestamp_seconds: it has no run to report")
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -12,26 +12,27 @@ import (
 type DagsterCollector struct {
 	dagsterGraphQLEndpoint string
 
-	activeRunsDesc                     *prometheus.Desc
-	completedRunsCounter               *prometheus.CounterVec
-	lastRunStatusDesc                  *prometheus.Desc
-	scrapeDurationDesc                 *prometheus.Desc
-	lastScrapeSuccessDesc              *prometheus.Desc
-	scrapeErrorsCounter                *prometheus.CounterVec
-	codeLocationLoadErrorDesc          *prometheus.Desc
-	lastRunDurationDesc                *prometheus.Desc
-	activeRunDurationDesc              *prometheus.Desc
-	concurrencyKeyBacklogDesc          *prometheus.Desc
-	scheduleStatusDesc                 *prometheus.Desc
-	scheduleTickStatusDesc             *prometheus.Desc
-	scheduleTickTimestampDesc          *prometheus.Desc
-	sensorStatusDesc                   *prometheus.Desc
-	sensorTickStatusDesc               *prometheus.Desc
-	sensorTickTimestampDesc            *prometheus.Desc
-	daemonHealthyDesc                  *prometheus.Desc
-	daemonLastHeartbeatDesc            *prometheus.Desc
-	assetStaleStatusDesc               *prometheus.Desc
-	assetLastMaterializationStatusDesc *prometheus.Desc
+	activeRunsDesc                        *prometheus.Desc
+	completedRunsCounter                  *prometheus.CounterVec
+	lastRunStatusDesc                     *prometheus.Desc
+	scrapeDurationDesc                    *prometheus.Desc
+	lastScrapeSuccessDesc                 *prometheus.Desc
+	scrapeErrorsCounter                   *prometheus.CounterVec
+	codeLocationLoadErrorDesc             *prometheus.Desc
+	lastRunDurationDesc                   *prometheus.Desc
+	activeRunDurationDesc                 *prometheus.Desc
+	concurrencyKeyBacklogDesc             *prometheus.Desc
+	scheduleStatusDesc                    *prometheus.Desc
+	scheduleTickStatusDesc                *prometheus.Desc
+	scheduleTickTimestampDesc             *prometheus.Desc
+	sensorStatusDesc                      *prometheus.Desc
+	sensorTickStatusDesc                  *prometheus.Desc
+	sensorTickTimestampDesc               *prometheus.Desc
+	daemonHealthyDesc                     *prometheus.Desc
+	daemonLastHeartbeatDesc               *prometheus.Desc
+	assetStaleStatusDesc                  *prometheus.Desc
+	assetLastMaterializationStatusDesc    *prometheus.Desc
+	assetLastMaterializationTimestampDesc *prometheus.Desc
 
 	mutex                   sync.Mutex
 	activeRunAggregates     map[ActiveRunKey]activeRunAggregate
@@ -204,6 +205,12 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"asset_key", "status"},
 			nil,
 		),
+		assetLastMaterializationTimestampDesc: prometheus.NewDesc(
+			"dagster_asset_last_materialization_timestamp_seconds",
+			"Unix timestamp (endTime) of an asset's most recent materializing run, regardless of whether it succeeded. Absent for an asset that has never had a run -- the same run this comes from also drives the last-materialization status metric. Exported as a timestamp rather than an age so staleness is computed at query time (time() - metric), not frozen at scrape time",
+			[]string{"asset_key"},
+			nil,
+		),
 		processedRuns:                cache,
 		lookbackWindow:               lookbackWindow,
 		lastRunStatus:                make(map[JobKey]lastRunEntry),
@@ -233,6 +240,7 @@ func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.daemonLastHeartbeatDesc
 	ch <- c.assetStaleStatusDesc
 	ch <- c.assetLastMaterializationStatusDesc
+	ch <- c.assetLastMaterializationTimestampDesc
 	c.completedRunsCounter.Describe(ch)
 	c.scrapeErrorsCounter.Describe(ch)
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -11,7 +11,7 @@ import (
 func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
 	c := NewDagsterCollector(t.Context(), "http://example.invalid", time.Hour, time.Hour, 500, 5*time.Minute)
 
-	descCh := make(chan *prometheus.Desc, 16)
+	descCh := make(chan *prometheus.Desc, 32)
 	go func() {
 		c.Describe(descCh)
 		close(descCh)
@@ -26,9 +26,10 @@ func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
 	// scheduleTickTimestampDesc, sensorStatusDesc, sensorTickStatusDesc,
 	// sensorTickTimestampDesc, daemonHealthyDesc, daemonLastHeartbeatDesc,
 	// assetStaleStatusDesc, assetLastMaterializationStatusDesc,
+	// assetLastMaterializationTimestampDesc,
 	// plus one each from completedRunsCounter and
 	// scrapeErrorsCounter.
-	assert.Equal(t, 20, descCount)
+	assert.Equal(t, 21, descCount)
 
 	c.RecordScrapeResult("active_runs", 10*time.Millisecond, nil)
 

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -485,7 +485,8 @@ type GraphQLAssetsLatestInfoResponse struct {
 				Path AssetKeyPath `json:"path"`
 			} `json:"assetKey"`
 			LatestRun *struct {
-				Status string `json:"status"`
+				Status  string  `json:"status"`
+				EndTime float64 `json:"endTime"`
 			} `json:"latestRun"`
 		} `json:"assetsLatestInfo"`
 	} `json:"data"`

--- a/internal/collector/queries/get_assets_latest_info.graphql
+++ b/internal/collector/queries/get_assets_latest_info.graphql
@@ -5,6 +5,7 @@ query GetAssetsLatestInfo($assetKeys: [AssetKeyInput!]!) {
     }
     latestRun {
       status
+      endTime
     }
   }
 }


### PR DESCRIPTION
## What

Adds `dagster_asset_last_materialization_timestamp_seconds{asset_key}` (Gauge) — the Unix timestamp of an asset's most recent materializing run (`assetsLatestInfo.latestRun.endTime`), regardless of outcome.

No new GraphQL query is needed: `internal/collector/asset_status.go` already queries `assetsLatestInfo.latestRun.status` for `dagster_asset_last_materialization_status`, so this just reads one more field (`endTime`) off the same response.

## Why

`dagster_asset_stale_status` only detects staleness *relative to an upstream* — it's a `code_version` comparison, not elapsed time. A leaf/source asset with no upstream dependency (e.g. `good_asset`) reports `fresh` forever once materialized once, even if it hasn't actually run again in months. There was no way to alert on "this asset hasn't been materialized recently" from the existing asset metrics.

This is the same gap #84 found and fixed for schedules/sensors: `dagster_schedule_last_tick_status`/`dagster_sensor_last_tick_status` freeze at their last value and can't tell "still working" from "silently stopped" on their own, which is why the tick-timestamp companions exist. `dagster_asset_last_materialization_status` has the identical blind spot.

`endTime` (not `updateTime`) matches the existing convention: `dagster_last_run_duration_seconds` already uses `endTime - creationTime` for completed jobs.

Absent-series semantics match `dagster_asset_last_materialization_status`: no series for an asset that's never had a run — both are gated on the same non-nil `LatestRun`.

## QA

Verified end-to-end per the `verify-metric` skill against the real dev stack:

- Materialized `good_asset`/`bad_asset` and confirmed the series reaches `/metrics` with a real `endTime` once each run terminates (`0` while still starting/started, matching the sibling status metric's non-terminal states).
- Confirmed Prometheus ingestion.
- Added an "Asset Materialization Age" panel to the Grafana dashboard, then swept every other panel afterward — only the unrelated, not-triggered-this-run Run Queue Backlog panel came back empty (expected).
- `go build ./...` and `go test ./...` pass.

## Ref

Closes #110

Precedent: #84