### PR TITLE
Bump chart to 0.1.6, appVersion to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Or deploy to Kubernetes with the [Helm chart](charts/dagster-prometheus-exporter
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.5 \
+  --version 0.1.6 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 

--- a/charts/dagster-prometheus-exporter/Chart.yaml
+++ b/charts/dagster-prometheus-exporter/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: dagster-prometheus-exporter
 description: A Prometheus exporter for Dagster run metrics
 type: application
-version: 0.1.5
+version: 0.1.6
 # Must exactly match a real tag on ghcr.io/hirofumitsuda/dagster-prometheus-exporter
 # (no "v" prefix — docker/metadata-action's {{version}} pattern in
 # docker-publish.yml strips it from the git tag when publishing), since
 # templates/deployment.yaml defaults image.tag to this value.
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 home: https://github.com/HirofumiTsuda/dagster-prometheus-exporter
 sources:
   - https://github.com/HirofumiTsuda/dagster-prometheus-exporter

--- a/charts/dagster-prometheus-exporter/README.md
+++ b/charts/dagster-prometheus-exporter/README.md
@@ -8,7 +8,7 @@ The chart is published as an OCI artifact to GHCR:
 
 ```sh
 helm install my-dagster-exporter oci://ghcr.io/hirofumitsuda/charts/dagster-prometheus-exporter \
-  --version 0.1.5 \
+  --version 0.1.6 \
   --set env.DAGSTER_GRAPHQL_ENDPOINT=http://dagster-webserver.dagster.svc.cluster.local/graphql
 ```
 


### PR DESCRIPTION
## What

Bumps the Helm chart to `0.1.6` and its `appVersion` to `0.5.0`.

## Why

Ahead of tagging `chart-v0.1.6`, following the established order (app tag → image published → chart bump → chart tag), since `helm-lint.yml` verifies the chart's default image actually exists on GHCR.

This release covers everything merged since `chart-v0.1.5`:

- #114 — `nodeSelector`/`tolerations`/`affinity` support
- #110 (app-side) — `dagster_asset_last_materialization_timestamp_seconds`, reflected here only via the `appVersion` bump

#113 (PrometheusRule alerts) is still under discussion and not included.

## QA

- `v0.5.0` already published and pullable; `dagster_exporter_build_info{commit=...}` confirmed to match `main` HEAD.
- `helm lint --strict charts/dagster-prometheus-exporter` passes.
- `helm template` with default values resolves the image to `ghcr.io/hirofumitsuda/dagster-prometheus-exporter:0.5.0`, which exists on GHCR.

## Ref

N/A