### PR TITLE
Add op pool concurrency metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Full label reference, edge cases, and design rationale for every metric below: [
 | `dagster_daemon_last_heartbeat_timestamp_seconds` | Gauge | When each daemon last reported a heartbeat. |
 | `dagster_code_location_load_error` | Gauge | Whether a code location most recently failed to load. |
 | `dagster_run_queue_concurrency_key_backlog` | Gauge | Runs queued behind a tag-based run-queue concurrency limit, per `dagster/concurrency_key` value. |
+| `dagster_op_pool_concurrency_active_slots` | Gauge | Slots currently claimed (steps actively running) against an op/step concurrency pool, per pool — a separate mechanism from the run-queue backlog above. |
+| `dagster_op_pool_concurrency_assigned_steps` | Gauge | Steps assigned a slot against a pool but not yet running, per pool. |
+| `dagster_op_pool_concurrency_pending_steps` | Gauge | Steps waiting for a slot against a pool, not yet assigned one, per pool. |
+| `dagster_op_pool_concurrency_limit` | Gauge | Effective concurrency limit configured for a pool, per pool — divide into active slots for utilization. |
 | `dagster_schedule_status` | Gauge | Whether a schedule is currently on or off. |
 | `dagster_schedule_last_tick_status` | Gauge | Outcome of a schedule's most recent tick. |
 | `dagster_schedule_last_tick_timestamp_seconds` | Gauge | When a schedule last ticked, so a stalled schedule is detectable. |
@@ -116,7 +120,7 @@ Full label reference, edge cases, and design rationale for every metric below: [
 
 ### Exporter self-health
 
-These report on the exporter itself rather than on Dagster's run state. The first three are labeled `collector` (one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status`, `daemon_health`, `asset_status` — see [docs/architecture.md](docs/architecture.md)).
+These report on the exporter itself rather than on Dagster's run state. The first three are labeled `collector` (one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status`, `daemon_health`, `asset_status`, `op_pool_concurrency` — see [docs/architecture.md](docs/architecture.md)).
 
 | Metric | Type | Description |
 | --- | --- | --- |
@@ -146,6 +150,11 @@ dagster_last_run_info{job_name="failing_job",location="dev-dagster-workspace",st
 dagster_last_run_duration_seconds{job_name="heavy_job",location="dev-dagster-workspace",status="success"} 32.34893083572388
 
 dagster_run_queue_concurrency_key_backlog{concurrency_key="heavy_limit"} 3
+
+dagster_op_pool_concurrency_active_slots{pool="heavy_pool"} 1
+dagster_op_pool_concurrency_assigned_steps{pool="heavy_pool"} 1
+dagster_op_pool_concurrency_pending_steps{pool="heavy_pool"} 1
+dagster_op_pool_concurrency_limit{pool="heavy_pool",using_default_limit="true"} 1
 
 dagster_schedule_status{schedule_name="daily_refresh",location="dev-dagster-workspace",status="running"} 1
 
@@ -193,6 +202,14 @@ topk(5, dagster_last_run_duration_seconds)
 
 # Which concurrency keys currently have a run-queue backlog
 dagster_run_queue_concurrency_key_backlog > 0
+
+# Op pool utilization -- how full each pool's claimed slots are
+dagster_op_pool_concurrency_active_slots
+/
+dagster_op_pool_concurrency_limit
+
+# Pools with steps genuinely waiting on a slot right now
+dagster_op_pool_concurrency_pending_steps > 0
 
 # Schedules that are turned on but whose last tick wasn't a success
 # (covers both a hard failure and a skip)
@@ -320,6 +337,25 @@ Each produces a different tick status, so all three show up at once and an alert
 | `failing_sensor` | `failure` | `minimum_interval_seconds=30`, always raises |
 
 `failing_sensor` logs an error on every evaluation by design — intentional, like `failing_job` and the broken code location, not a sign the dev stack is misconfigured.
+
+### Testing op pool concurrency
+
+Like the broken-code-location fixture, this needs a manual trigger. `dev/dagster_workspace/job.py` defines two jobs behind a `heavy_pool` op/step concurrency pool (`dagster.yaml` sets `concurrency.pools.default_limit: 1`, so the pool has exactly one slot):
+
+| Fixture | What it exercises |
+| --- | --- |
+| `heavy_pool_job` | One op behind `heavy_pool`. Launch it twice back to back (Dagit → Launchpad, or the GraphQL API) and the second run queues behind the first — but **only as a whole run**; see the note below. |
+| `heavy_pool_fanout_job` | Two independent ops behind `heavy_pool`, run with `multiprocess_executor(max_concurrent=2)` so both are actually submitted for execution at once. Launch it once. |
+
+**`dagster_op_pool_concurrency_pending_steps` needs `heavy_pool_fanout_job`, not two launches of `heavy_pool_job`.** Verified live against 1.13.15: a run blocked at the run-queue admission level (two separate `heavy_pool_job` runs contending for the pool) never submits a step for execution at all, so it never shows up as pending — it just stays `QUEUED` as a whole run, same as the tag-based backlog above. Only a step that has actually been submitted and is waiting on a slot counts as pending, which needs two ops *within the same already-started run* contending for one slot — exactly what `heavy_pool_fanout_job` sets up. Launching it once produces all three states simultaneously:
+
+```
+dagster_op_pool_concurrency_active_slots{pool="heavy_pool"} 1
+dagster_op_pool_concurrency_assigned_steps{pool="heavy_pool"} 1
+dagster_op_pool_concurrency_pending_steps{pool="heavy_pool"} 1
+```
+
+Also verified live: `concurrency.pools.granularity` has to be `"op"`, not `"run"`, for any of this to be observable at all. Under `"run"` granularity, a pool's limit is still enforced at the run-queue admission level, but the exporter's four metrics — which read `instance.concurrencyLimits`, backed by Dagster's per-step slot-claiming tables — stay at `0` regardless, because run-granularity enforcement never actually claims a per-step slot. `dagster_op_pool_concurrency_limit` is the exception: it always reflects the pool's configured limit either way.
 
 ### Testing asset staleness
 

--- a/dev/dagster_home/dagster.yaml
+++ b/dev/dagster_home/dagster.yaml
@@ -1,6 +1,23 @@
 concurrency:
   pools:
-    granularity: "run"
+    # "op", not "run" -- verified live (issue #111): under "run" granularity
+    # a pool's ConcurrencyLimitsTable row still gets created (so
+    # instance.concurrencyLimits lists the pool and its limit), but the
+    # actual per-step slot claiming that populates activeSlotCount/
+    # pendingStepCount/assignedStepCount never happens -- run-granularity
+    # enforcement is front-loaded entirely into the run-queue admission
+    # decision, with nothing written to ConcurrencySlotsTable/
+    # PendingStepsTable afterward. Confirmed by launching two concurrent
+    # runs against heavy_pool under "run" granularity and watching both
+    # start immediately with every count staying at 0. "op" granularity is
+    # what actually exercises dagster_op_pool_concurrency_active_slots/
+    # _pending_steps/_assigned_steps.
+    granularity: "op"
+    # Deliberately 1: exercises dagster_op_pool_concurrency_pending_steps
+    # (see heavy_pool_job in dev/dagster_workspace/job.py) by making two
+    # concurrent runs against the same pool contend for a single slot,
+    # without needing a per-pool override.
+    default_limit: 1
   runs:
     tag_concurrency_limits:
     - key: "dagster/concurrency_key"

--- a/dev/dagster_workspace/job.py
+++ b/dev/dagster_workspace/job.py
@@ -8,6 +8,7 @@ from dagster import (
     SkipReason,
     asset,
     job,
+    multiprocess_executor,
     op,
     sensor,
 )
@@ -46,7 +47,48 @@ def quick_job():
     quick_op()
 
 
-jobs = [heavy_job, failing_job, quick_job]
+@op(pool="heavy_pool")
+def heavy_pool_op():
+    """An op behind the heavy_pool concurrency pool (not the same mechanism
+    as heavy_job's dagster/concurrency_key tag -- see
+    dagster_op_pool_concurrency_active_slots in docs/metrics.md). Sleeps long
+    enough that launching heavy_pool_job a second time while the first is
+    still running holds heavy_pool's only slot (dagster.yaml's
+    concurrency.pools.default_limit: 1), for exercising
+    dagster_op_pool_concurrency_pending_steps/_assigned_steps."""
+    time.sleep(30)
+
+
+@job
+def heavy_pool_job():
+    heavy_pool_op()
+
+
+@op(pool="heavy_pool")
+def heavy_pool_op_b():
+    """A second op sharing heavy_pool_op's pool, with no data dependency
+    between them, so a single run of heavy_pool_fanout_job can exercise
+    dagster_op_pool_concurrency_pending_steps within one run. Launching
+    heavy_pool_job twice, by contrast, only ever contends at the run-queue
+    admission level (see dagster.yaml's concurrency.pools comment) --
+    verified live: a run blocked there never submits a step at all, so
+    pendingStepCount stays 0 no matter how many runs pile up against the
+    pool. Only a step that's actually been submitted for execution and is
+    waiting on a slot counts as pending."""
+    time.sleep(15)
+
+
+# max_concurrent=2 so both ops are actually submitted for execution at once
+# (the default executor here would run them sequentially in-process, in
+# which case op_b would never be submitted until heavy_pool_op finished and
+# freed the slot itself -- never observably pending).
+@job(executor_def=multiprocess_executor.configured({"max_concurrent": 2}))
+def heavy_pool_fanout_job():
+    heavy_pool_op()
+    heavy_pool_op_b()
+
+
+jobs = [heavy_job, failing_job, quick_job, heavy_pool_job, heavy_pool_fanout_job]
 
 # default_status=RUNNING so it's already ticking without a manual toggle in
 # the UI/API — see the "Testing schedule tick status" section in README.md.

--- a/dev/grafana/dashboards/dagster-dashboard.json
+++ b/dev/grafana/dashboards/dagster-dashboard.json
@@ -961,6 +961,48 @@
         "x": 0,
         "y": 77
       }
+    },
+    {
+      "title": "Op Pool Concurrency",
+      "description": "Steps behind an op/step concurrency pool, by state: active (slot claimed, step running), assigned (slot reserved, not yet running), pending (waiting, not yet assigned). A different mechanism from Run Queue Backlog by Concurrency Key: this tracks individual steps sharing a pool across the whole instance, not whole runs queued behind a run-level tag.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "dagster_op_pool_concurrency_active_slots",
+          "legendFormat": "{{pool}} active"
+        },
+        {
+          "expr": "dagster_op_pool_concurrency_assigned_steps",
+          "legendFormat": "{{pool}} assigned"
+        },
+        {
+          "expr": "dagster_op_pool_concurrency_pending_steps",
+          "legendFormat": "{{pool}} pending"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 85
+      }
+    },
+    {
+      "title": "Op Pool Concurrency Limit",
+      "description": "Effective slot limit per pool. using_default_limit=true means the pool has no explicit override and is running on dagster.yaml's concurrency.pools.default_limit.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "dagster_op_pool_concurrency_limit",
+          "legendFormat": "{{pool}} (default={{using_default_limit}})"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 85
+      }
     }
   ],
   "templating": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,13 +9,13 @@ The exporter is a single Go binary with no external state store — everything i
 - `cmd/exporter` — entrypoint; loads config and starts the server.
 - `internal/config` — reads settings from environment variables.
 - `internal/server` — runs the HTTP server (`/metrics`, `/healthz`, `/readyz`) and a background ticker that triggers a scrape on `DAGSTER_SCRAPING_INTERVAL_SECONDS`.
-- `internal/collector` — on each scrape, queries Dagster's GraphQL API (active runs, completed runs, the definitions roster, each code location's load status, daemon health, and asset status) and updates the in-memory state behind a mutex; `DagsterCollector` implements `prometheus.Collector` and renders that state into metrics whenever Prometheus scrapes `/metrics`.
+- `internal/collector` — on each scrape, queries Dagster's GraphQL API (active runs, completed runs, the definitions roster, each code location's load status, daemon health, asset status, and op/step pool concurrency) and updates the in-memory state behind a mutex; `DagsterCollector` implements `prometheus.Collector` and renders that state into metrics whenever Prometheus scrapes `/metrics`.
 
 Because scraping (writing state) and metrics rendering (reading state) are decoupled, a slow or failing Dagster GraphQL call never blocks or breaks a `/metrics` request — it just serves the last known state.
 
-## Why six collectors, and why they're split the way they are
+## Why seven collectors, and why they're split the way they are
 
-The six collectors (definitions roster, active runs, completed runs, code-location load status, daemon health, asset status) run concurrently on every scrape — each locks `DagsterCollector`'s own mutex only around its own critical section, so they don't block each other or `/metrics`.
+The seven collectors (definitions roster, active runs, completed runs, code-location load status, daemon health, asset status, op pool concurrency) run concurrently on every scrape — each locks `DagsterCollector`'s own mutex only around its own critical section, so they don't block each other or `/metrics`.
 
 The code-location load status collector is intentionally independent of the definitions-roster one: `repositoriesOrError` (used for the roster) silently omits a code location that fails to load rather than erroring out, so a separate `workspaceOrError` query is needed to detect that failure at all — see `dagster_code_location_load_error` in the [metrics reference](metrics.md).
 
@@ -24,6 +24,8 @@ The daemon-health collector is likewise independent: `instance.daemonHealth` is 
 The asset-status collector is a third independent one, and the only one that makes two GraphQL round trips instead of one: `assetNodes` (every asset defined, across every code location, no `repositorySelector` needed) has to run first, because `assetsLatestInfo` needs the asset keys it returns as its `assetKeys` argument. Neither field hangs off `repositoriesOrError`. See `dagster_asset_last_materialization_status` in the [metrics reference](metrics.md) for why staleness alone (`assetNodes.staleStatus`) can't tell a failed run apart from one that never happened.
 
 `dagster_run_queue_concurrency_key_backlog` is folded into the active-runs collector instead of getting its own: it only needs `QUEUED` runs' tags, which that collector already fetches on every page, so a separate query would just re-fetch the same runs a second time for no reason.
+
+The op-pool-concurrency collector is the opposite case: it can't be folded into anything else, because `instance.concurrencyLimits` is a top-level field with no relationship to runs, jobs, or repositories at all — it's Dagster's own event-log storage answering "how many slots are claimed against this pool right now," independent of which run or job a step belongs to. It also needs no zero-fill logic of its own (contrast with the active-runs collector's `dagster_run_queue_concurrency_key_backlog` handling, and see [#81](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/81)): Dagster's storage already remembers every pool that has ever claimed a slot and keeps reporting it at zero once idle, so the collector just replaces its whole map on every scrape instead of accumulating one.
 
 ## The definitions-roster collector
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -95,7 +95,7 @@ Labels: `concurrency_key`
 
 Number of runs currently `QUEUED` because of a tag-based run-queue concurrency limit (`dagster.yaml`'s `concurrency.runs.tag_concurrency_limits`), per `dagster/concurrency_key` tag value. Not job/location-scoped, since a concurrency key can be shared across jobs.
 
-Note: Dagster's `instance.concurrencyLimits` GraphQL query looks like it would answer this directly, but it doesn't — it's backed by a separate op/step "pool" concurrency store and reports `0` for run-level tag-based backlog regardless of how many runs are actually queued behind a key, so this is computed by reading each `QUEUED` run's own tags instead.
+Note: Dagster's `instance.concurrencyLimits` GraphQL query looks like it would answer this directly, but it doesn't — it's backed by a separate op/step "pool" concurrency store and reports `0` for run-level tag-based backlog regardless of how many runs are actually queued behind a key, so this is computed by reading each `QUEUED` run's own tags instead. `instance.concurrencyLimits` is the right field for *that* separate mechanism — see `dagster_op_pool_concurrency_active_slots`.
 
 A concurrency key is zero-filled (not dropped) once its backlog clears, for the same reason as `dagster_active_runs`: a missing series and a `0` mean different things.
 
@@ -173,9 +173,47 @@ This exists because `dagster_asset_stale_status` only detects staleness *relativ
 
 `endTime`, not `updateTime`, to match the existing convention: `dagster_last_run_duration_seconds` already uses `endTime - creationTime` for completed jobs, so this stays consistent with how "when did this run finish" is computed elsewhere in the codebase.
 
+## `dagster_op_pool_concurrency_active_slots` (Gauge)
+
+Labels: `pool`
+
+Number of slots currently claimed — steps actively running — against an op/step concurrency pool (Dagster's `pool` argument on `@op`/`@asset`, config'd via `dagster.yaml`'s `concurrency.pools`), per pool.
+
+This is a distinct mechanism from `dagster_run_queue_concurrency_key_backlog`: that one tracks whole *runs* stuck in the queue behind a run-level `dagster/concurrency_key` tag, this tracks individual *steps* sharing a named pool of slots across the whole instance, regardless of which run or job they belong to. Both are sourced from Dagster's `instance.concurrencyLimits` GraphQL field having the wrong name for one of them and the right name for the other — see that metric's own doc for the details of why it can't answer the run-queue question. The label is `pool`, not `concurrency_key`, specifically so the two don't read as the same thing in a dashboard or alert.
+
+A step behind a pool passes through up to three states: pending (waiting for a slot, not yet assigned one) → assigned (a slot is reserved for it, but it hasn't started) → active (the slot is claimed and the step is running) — see `dagster_op_pool_concurrency_assigned_steps` and `dagster_op_pool_concurrency_pending_steps` for the other two.
+
+Unlike the run-queue backlog, this metric needs no exporter-side zero-fill and grows no unbounded map of its own (the concern [#81](https://github.com/HirofumiTsuda/dagster-prometheus-exporter/issues/81) raised for that one): `instance.concurrencyLimits` is sourced from Dagster's own event-log storage, which persistently remembers every pool that has ever claimed a slot and keeps reporting it at zero once it goes idle — confirmed by reading `SqlEventLogStorage.get_concurrency_keys`/`get_concurrency_info` against the pinned Dagster version, not just the GraphQL schema. The exporter just reflects whatever comes back on each scrape; a pool that has never been used simply never appears.
+
+**Requires `concurrency.pools.granularity: "op"` in `dagster.yaml`.** Verified live: under the other setting, `"run"`, a pool's limit is still enforced (at the run-queue admission level — a whole run is blocked from starting if none of its root steps' pools have room), but no per-step slot is ever actually claimed in the tables this metric reads, so `active_slots`/`assigned_steps`/`pending_steps` all stay `0` regardless of real contention. `dagster_op_pool_concurrency_limit` is unaffected either way, since it reads the pool's configured limit directly rather than derived slot state. See [dev/dagster_home/dagster.yaml](../dev/dagster_home/dagster.yaml) and the "Testing op pool concurrency" section in the README for how the dev fixture exercises this.
+
+## `dagster_op_pool_concurrency_assigned_steps` (Gauge)
+
+Labels: `pool`
+
+Number of steps assigned a slot against an op/step concurrency pool but not yet running, per pool — the middle of the three states described under `dagster_op_pool_concurrency_active_slots`. Included separately from pending/active so a full count of "how many steps are behind this pool right now" doesn't undercount by ignoring it.
+
+## `dagster_op_pool_concurrency_pending_steps` (Gauge)
+
+Labels: `pool`
+
+Number of steps waiting for a slot against an op/step concurrency pool, not yet assigned one, per pool — the first of the three states described under `dagster_op_pool_concurrency_active_slots`.
+
+Only counts a step that has actually been submitted for execution and is waiting on a slot — not a whole run still sitting in Dagster's run queue because none of its root steps could get a slot. Verified live: a run blocked at that admission stage never submits a step at all, so it contributes nothing here (it shows up as a `QUEUED` run instead, the same situation `dagster_run_queue_concurrency_key_backlog` was built for, just for a different concurrency mechanism). Seeing a nonzero value needs steps *within an already-started run* genuinely contending for a pool's slot — see the README's "Testing op pool concurrency" section for how the dev fixture sets that up.
+
+## `dagster_op_pool_concurrency_limit` (Gauge)
+
+Labels: `pool`, `using_default_limit`
+
+Effective concurrency limit (number of slots) configured for an op/step concurrency pool, per pool. Divide it into `dagster_op_pool_concurrency_active_slots` for utilization.
+
+`using_default_limit` is `"true"` when the pool has no explicit limit of its own and is running on the instance-wide default (`dagster.yaml`'s `concurrency.pools.default_limit`), `"false"` when it has been given one explicitly.
+
+Absent for a pool Dagster reports no limit for at all — the schema makes `limit` nullable, though in practice (checked against the pinned Dagster version's resolver) that only happens for a pool with no claimed slots and no configured instance-wide default; every pool that has actually done anything has a concrete limit.
+
 ## Exporter self-health
 
-These report on the exporter itself, rather than on Dagster's run state. The first three are about whether its own scrapes of Dagster are succeeding, and are labeled `collector`, one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status`, `daemon_health`, or `asset_status` (the six concurrent collectors described in [docs/architecture.md](architecture.md)).
+These report on the exporter itself, rather than on Dagster's run state. The first three are about whether its own scrapes of Dagster are succeeding, and are labeled `collector`, one of `definitions_roster`, `active_runs`, `completed_runs`, `code_location_status`, `daemon_health`, `asset_status`, or `op_pool_concurrency` (the seven concurrent collectors described in [docs/architecture.md](architecture.md)).
 
 ### `dagster_exporter_scrape_duration_seconds` (Gauge)
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -33,6 +33,10 @@ type DagsterCollector struct {
 	assetStaleStatusDesc                  *prometheus.Desc
 	assetLastMaterializationStatusDesc    *prometheus.Desc
 	assetLastMaterializationTimestampDesc *prometheus.Desc
+	opPoolActiveSlotsDesc                 *prometheus.Desc
+	opPoolAssignedStepsDesc               *prometheus.Desc
+	opPoolPendingStepsDesc                *prometheus.Desc
+	opPoolLimitDesc                       *prometheus.Desc
 
 	mutex                   sync.Mutex
 	activeRunAggregates     map[ActiveRunKey]activeRunAggregate
@@ -52,6 +56,7 @@ type DagsterCollector struct {
 	codeLocationLoadError   map[string]bool
 	daemonHealth            map[string]daemonHealthEntry
 	assetStatus             map[string]assetStatusEntry
+	opPoolConcurrency       map[string]opPoolConcurrencyEntry
 	// runsUpdatedAfterSafetyMargin is subtracted from the last-seen
 	// updateTime watermark before it's used as the next scrape's
 	// updatedAfter. A run's updateTime can be set slightly before its write
@@ -211,6 +216,30 @@ func NewDagsterCollector(ctx context.Context, dagsterGraphQLEndpoint string, loo
 			[]string{"asset_key"},
 			nil,
 		),
+		opPoolActiveSlotsDesc: prometheus.NewDesc(
+			"dagster_op_pool_concurrency_active_slots",
+			"Number of slots currently claimed (steps actively running) against an op/step concurrency pool, per pool",
+			[]string{"pool"},
+			nil,
+		),
+		opPoolAssignedStepsDesc: prometheus.NewDesc(
+			"dagster_op_pool_concurrency_assigned_steps",
+			"Number of steps assigned a slot against an op/step concurrency pool but not yet running, per pool",
+			[]string{"pool"},
+			nil,
+		),
+		opPoolPendingStepsDesc: prometheus.NewDesc(
+			"dagster_op_pool_concurrency_pending_steps",
+			"Number of steps waiting for a slot against an op/step concurrency pool, not yet assigned one, per pool",
+			[]string{"pool"},
+			nil,
+		),
+		opPoolLimitDesc: prometheus.NewDesc(
+			"dagster_op_pool_concurrency_limit",
+			"Effective concurrency limit (number of slots) configured for an op/step concurrency pool, per pool. Absent for a pool Dagster reports no limit for (see docs/metrics.md)",
+			[]string{"pool", "using_default_limit"},
+			nil,
+		),
 		processedRuns:                cache,
 		lookbackWindow:               lookbackWindow,
 		lastRunStatus:                make(map[JobKey]lastRunEntry),
@@ -241,6 +270,10 @@ func (c *DagsterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.assetStaleStatusDesc
 	ch <- c.assetLastMaterializationStatusDesc
 	ch <- c.assetLastMaterializationTimestampDesc
+	ch <- c.opPoolActiveSlotsDesc
+	ch <- c.opPoolAssignedStepsDesc
+	ch <- c.opPoolPendingStepsDesc
+	ch <- c.opPoolLimitDesc
 	c.completedRunsCounter.Describe(ch)
 	c.scrapeErrorsCounter.Describe(ch)
 }
@@ -257,6 +290,7 @@ func (c *DagsterCollector) Collect(ch chan<- prometheus.Metric) {
 	reflectSensorTickStatus(c, ch)
 	reflectDaemonHealth(c, ch)
 	reflectAssetStatus(c, ch)
+	reflectOpPoolConcurrency(c, ch)
 	c.completedRunsCounter.Collect(ch)
 	c.scrapeErrorsCounter.Collect(ch)
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -26,10 +26,11 @@ func TestDagsterCollectorDescribeAndCollect(t *testing.T) {
 	// scheduleTickTimestampDesc, sensorStatusDesc, sensorTickStatusDesc,
 	// sensorTickTimestampDesc, daemonHealthyDesc, daemonLastHeartbeatDesc,
 	// assetStaleStatusDesc, assetLastMaterializationStatusDesc,
-	// assetLastMaterializationTimestampDesc,
+	// assetLastMaterializationTimestampDesc, opPoolActiveSlotsDesc,
+	// opPoolAssignedStepsDesc, opPoolPendingStepsDesc, opPoolLimitDesc,
 	// plus one each from completedRunsCounter and
 	// scrapeErrorsCounter.
-	assert.Equal(t, 21, descCount)
+	assert.Equal(t, 25, descCount)
 
 	c.RecordScrapeResult("active_runs", 10*time.Millisecond, nil)
 

--- a/internal/collector/graphql.go
+++ b/internal/collector/graphql.go
@@ -524,6 +524,55 @@ func getAssetsLatestInfo(ctx context.Context, request *GraphQLRequest, dagsterGr
 	return &resp, nil
 }
 
+// GraphQLConcurrencyLimitsResponse is the shape of instance.concurrencyLimits:
+// Dagster's op/step "pool" concurrency accounting (see CollectOpPoolConcurrency
+// for why this is a different mechanism from the run-queue's
+// dagster/concurrency_key tag). Like GraphQLDaemonHealthResponse, instance
+// and concurrencyLimits are both non-null object/list types in the schema,
+// so there's no __typename to check here.
+//
+// limit and usingDefaultLimit are nullable in the schema. In practice,
+// reading the pinned 1.13.15's resolver
+// (dagster/_utils/concurrency.py's ConcurrencyKeyInfo, backing
+// SqlEventLogStorage.get_concurrency_info) shows limit only comes back null
+// for a pool with no slots yet *and* no instance-wide default configured —
+// every pool that has actually claimed a slot has a concrete limit. Kept as
+// a pointer anyway rather than assumed non-null, the same defensive choice
+// GraphQLDaemonHealthResponse makes for Healthy/LastHeartbeatTime.
+type GraphQLConcurrencyLimitsResponse struct {
+	Data struct {
+		Instance struct {
+			ConcurrencyLimits []struct {
+				ConcurrencyKey    string `json:"concurrencyKey"`
+				ActiveSlotCount   int    `json:"activeSlotCount"`
+				AssignedStepCount int    `json:"assignedStepCount"`
+				PendingStepCount  int    `json:"pendingStepCount"`
+				Limit             *int   `json:"limit"`
+				UsingDefaultLimit *bool  `json:"usingDefaultLimit"`
+			} `json:"concurrencyLimits"`
+		} `json:"instance"`
+	} `json:"data"`
+	graphQLErrors
+}
+
+//go:embed queries/get_concurrency_limits.graphql
+var concurrencyLimitsQuery string
+
+func getConcurrencyLimitsRequest() *GraphQLRequest {
+	return &GraphQLRequest{
+		Query: concurrencyLimitsQuery,
+	}
+}
+
+func getConcurrencyLimits(ctx context.Context, request *GraphQLRequest, dagsterGraphQLEndpoint string) (*GraphQLConcurrencyLimitsResponse, error) {
+	var resp GraphQLConcurrencyLimitsResponse
+	if err := doGraphQL(ctx, request, dagsterGraphQLEndpoint, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 //go:embed queries/get_version.graphql
 var versionQuery string
 

--- a/internal/collector/op_pool_concurrency.go
+++ b/internal/collector/op_pool_concurrency.go
@@ -1,0 +1,137 @@
+package collector
+
+import (
+	"context"
+	"log"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// opPoolConcurrencyEntry is one op pool's most recently observed slot
+// accounting.
+//
+// A step behind a pool passes through up to three states, not two: pending
+// (waiting for a slot, unassigned) -> assigned (a slot has been reserved for
+// it, but it hasn't started) -> active (the slot is claimed and the step is
+// running). Dropping the "assigned" state would undercount how many steps
+// are actually behind a pool, so all three are tracked separately rather
+// than collapsing assigned into pending or active.
+type opPoolConcurrencyEntry struct {
+	activeSlots   int
+	assignedSteps int
+	pendingSteps  int
+	// hasLimit gates emitting dagster_op_pool_concurrency_limit, the same
+	// pattern reflectAssetStatus uses for lastMaterializationStatus == "":
+	// limit is nullable in the schema (see GraphQLConcurrencyLimitsResponse),
+	// so a pool with neither slots nor a configured default has none to
+	// report.
+	hasLimit          bool
+	limit             int
+	usingDefaultLimit bool
+}
+
+// CollectOpPoolConcurrency reports Dagster's op/step "pool" concurrency
+// accounting: how many slots are claimed, how many steps are queued behind
+// a pool, and its effective limit.
+//
+// This is a different mechanism from dagster_run_queue_concurrency_key_backlog
+// (see concurrencyKeyTag's doc comment in collector.go), which tracks whole
+// *runs* stuck behind a run-level dagster/concurrency_key tag.
+// instance.concurrencyLimits is exactly the wrong field for that question —
+// but it's exactly the right one for op-pool visibility, a genuinely
+// separate gap (#111). The two mechanisms' labels are kept visibly distinct
+// (concurrency_key vs pool below) so a reader doesn't conflate them despite
+// the similar metric names.
+//
+// Unlike the run-queue backlog, no exporter-side zero-fill is needed here.
+// instance.concurrencyLimits is sourced from Dagster's own event-log storage
+// (SqlEventLogStorage.get_concurrency_keys, read against the pinned
+// 1.13.15), which persistently remembers every pool that has ever claimed a
+// slot and keeps returning it -- with zero counts -- once it goes idle. So
+// CollectOpPoolConcurrency just replaces c.opPoolConcurrency wholesale on
+// every scrape, the same pattern as CollectDaemonHealth/CollectAssetStatus:
+// a pool that has never been used simply doesn't appear, which is the
+// correct "never seen" signal without this exporter growing an unbounded
+// map of its own the way #81 flagged for the run-queue backlog.
+//
+// instance and concurrencyLimits are both top-level, non-null fields -- not
+// reachable via repositoriesOrError -- so this is its own query and its own
+// collector, the same reasoning as CollectDaemonHealth.
+func CollectOpPoolConcurrency(ctx context.Context, c *DagsterCollector) error {
+	req := getConcurrencyLimitsRequest()
+
+	resp, err := getConcurrencyLimits(ctx, req, c.dagsterGraphQLEndpoint)
+	if err != nil {
+		log.Printf("failed to collect op pool concurrency from dagster: %v", err)
+		return err
+	}
+
+	limits := resp.Data.Instance.ConcurrencyLimits
+	entries := make(map[string]opPoolConcurrencyEntry, len(limits))
+	for _, l := range limits {
+		entry := opPoolConcurrencyEntry{
+			activeSlots:   l.ActiveSlotCount,
+			assignedSteps: l.AssignedStepCount,
+			pendingSteps:  l.PendingStepCount,
+		}
+		if l.Limit != nil {
+			entry.hasLimit = true
+			entry.limit = *l.Limit
+			if l.UsingDefaultLimit != nil {
+				entry.usingDefaultLimit = *l.UsingDefaultLimit
+			}
+		}
+		entries[l.ConcurrencyKey] = entry
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.opPoolConcurrency = entries
+
+	return nil
+}
+
+// reflectOpPoolConcurrency emits dagster_op_pool_concurrency_active_slots,
+// _assigned_steps, _pending_steps, and _limit from a single locked pass, the
+// same reasoning as reflectDaemonHealth: all four come from one entry per
+// pool.
+func reflectOpPoolConcurrency(c *DagsterCollector, ch chan<- prometheus.Metric) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for pool, entry := range c.opPoolConcurrency {
+		ch <- prometheus.MustNewConstMetric(
+			c.opPoolActiveSlotsDesc,
+			prometheus.GaugeValue,
+			float64(entry.activeSlots),
+			pool,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.opPoolAssignedStepsDesc,
+			prometheus.GaugeValue,
+			float64(entry.assignedSteps),
+			pool,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.opPoolPendingStepsDesc,
+			prometheus.GaugeValue,
+			float64(entry.pendingSteps),
+			pool,
+		)
+
+		if entry.hasLimit {
+			usingDefaultLimit := "false"
+			if entry.usingDefaultLimit {
+				usingDefaultLimit = "true"
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.opPoolLimitDesc,
+				prometheus.GaugeValue,
+				float64(entry.limit),
+				pool,
+				usingDefaultLimit,
+			)
+		}
+	}
+}

--- a/internal/collector/op_pool_concurrency_test.go
+++ b/internal/collector/op_pool_concurrency_test.go
@@ -1,0 +1,150 @@
+package collector
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// concurrencyLimitsBody mirrors what a live Dagster 1.13.15 returns: one
+// pool with a mix of active/assigned/pending steps and an explicit limit,
+// one idle pool sitting on the instance-wide default limit, and one pool
+// that has claimed slots but has no limit at all (the nullable case).
+const concurrencyLimitsBody = `{
+	"data": {
+		"instance": {
+			"concurrencyLimits": [
+				{"concurrencyKey": "db_pool", "activeSlotCount": 2, "assignedStepCount": 1, "pendingStepCount": 3, "limit": 4, "usingDefaultLimit": false},
+				{"concurrencyKey": "idle_pool", "activeSlotCount": 0, "assignedStepCount": 0, "pendingStepCount": 0, "limit": 1, "usingDefaultLimit": true},
+				{"concurrencyKey": "no_limit_pool", "activeSlotCount": 1, "assignedStepCount": 0, "pendingStepCount": 0, "limit": null, "usingDefaultLimit": null}
+			]
+		}
+	}
+}`
+
+func concurrencyLimitsServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(body))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestCollectOpPoolConcurrency(t *testing.T) {
+	ts := concurrencyLimitsServer(t, concurrencyLimitsBody)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+
+	require.NoError(t, CollectOpPoolConcurrency(t.Context(), c))
+
+	require.Len(t, c.opPoolConcurrency, 3)
+
+	dbPool := c.opPoolConcurrency["db_pool"]
+	assert.Equal(t, 2, dbPool.activeSlots)
+	assert.Equal(t, 1, dbPool.assignedSteps)
+	assert.Equal(t, 3, dbPool.pendingSteps)
+	require.True(t, dbPool.hasLimit)
+	assert.Equal(t, 4, dbPool.limit)
+	assert.False(t, dbPool.usingDefaultLimit)
+
+	idlePool := c.opPoolConcurrency["idle_pool"]
+	assert.Equal(t, 0, idlePool.activeSlots)
+	require.True(t, idlePool.hasLimit)
+	assert.Equal(t, 1, idlePool.limit)
+	assert.True(t, idlePool.usingDefaultLimit)
+
+	noLimitPool := c.opPoolConcurrency["no_limit_pool"]
+	assert.Equal(t, 1, noLimitPool.activeSlots)
+	assert.False(t, noLimitPool.hasLimit,
+		"a null limit must stay unset, not become 0")
+}
+
+func TestCollectOpPoolConcurrencyReplacesMapWholesale(t *testing.T) {
+	// A pool that goes idle and stops appearing in a later response must
+	// disappear from c.opPoolConcurrency too -- unlike the run-queue
+	// backlog, this collector relies on Dagster's own storage to keep
+	// reporting an idle pool at zero, and should never itself zero-fill or
+	// retain a pool that Dagster has stopped returning.
+	ts := concurrencyLimitsServer(t, concurrencyLimitsBody)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+	require.NoError(t, CollectOpPoolConcurrency(t.Context(), c))
+	require.Contains(t, c.opPoolConcurrency, "db_pool")
+
+	ts2 := concurrencyLimitsServer(t, `{"data": {"instance": {"concurrencyLimits": []}}}`)
+	c.dagsterGraphQLEndpoint = ts2.URL
+	require.NoError(t, CollectOpPoolConcurrency(t.Context(), c))
+
+	assert.Empty(t, c.opPoolConcurrency)
+}
+
+func TestReflectOpPoolConcurrencyMetrics(t *testing.T) {
+	ts := concurrencyLimitsServer(t, concurrencyLimitsBody)
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+	require.NoError(t, CollectOpPoolConcurrency(t.Context(), c))
+
+	ch := make(chan prometheus.Metric, 32)
+	go func() {
+		reflectOpPoolConcurrency(c, ch)
+		close(ch)
+	}()
+
+	active := make(map[string]float64)
+	assigned := make(map[string]float64)
+	pending := make(map[string]float64)
+	limit := make(map[string]float64)
+	usingDefaultLimit := make(map[string]string)
+	for m := range ch {
+		var dm dto.Metric
+		require.NoError(t, m.Write(&dm))
+		labels := make(map[string]string)
+		for _, l := range dm.GetLabel() {
+			labels[l.GetName()] = l.GetValue()
+		}
+		pool := labels["pool"]
+		switch desc := m.Desc().String(); {
+		case strings.Contains(desc, "dagster_op_pool_concurrency_active_slots"):
+			active[pool] = dm.GetGauge().GetValue()
+		case strings.Contains(desc, "dagster_op_pool_concurrency_assigned_steps"):
+			assigned[pool] = dm.GetGauge().GetValue()
+		case strings.Contains(desc, "dagster_op_pool_concurrency_pending_steps"):
+			pending[pool] = dm.GetGauge().GetValue()
+		case strings.Contains(desc, "dagster_op_pool_concurrency_limit"):
+			limit[pool] = dm.GetGauge().GetValue()
+			usingDefaultLimit[pool] = labels["using_default_limit"]
+		}
+	}
+
+	assert.Equal(t, float64(2), active["db_pool"])
+	assert.Equal(t, float64(1), assigned["db_pool"])
+	assert.Equal(t, float64(3), pending["db_pool"])
+	assert.Equal(t, float64(4), limit["db_pool"])
+	assert.Equal(t, "false", usingDefaultLimit["db_pool"])
+
+	assert.Equal(t, float64(0), active["idle_pool"])
+	assert.Equal(t, float64(1), limit["idle_pool"])
+	assert.Equal(t, "true", usingDefaultLimit["idle_pool"])
+
+	assert.Equal(t, float64(1), active["no_limit_pool"])
+	assert.NotContains(t, limit, "no_limit_pool",
+		"a pool with no reported limit must produce no dagster_op_pool_concurrency_limit series at all")
+}
+
+func TestCollectOpPoolConcurrencyReturnsErrorOnServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c := NewDagsterCollector(t.Context(), ts.URL, time.Hour, time.Hour, 500, 5*time.Minute)
+	assert.Error(t, CollectOpPoolConcurrency(t.Context(), c))
+}

--- a/internal/collector/queries/get_concurrency_limits.graphql
+++ b/internal/collector/queries/get_concurrency_limits.graphql
@@ -1,0 +1,12 @@
+query GetConcurrencyLimits {
+  instance {
+    concurrencyLimits {
+      concurrencyKey
+      activeSlotCount
+      assignedStepCount
+      pendingStepCount
+      limit
+      usingDefaultLimit
+    }
+  }
+}

--- a/internal/server/scrape.go
+++ b/internal/server/scrape.go
@@ -31,6 +31,7 @@ func scrapeDagster(ctx context.Context, c *collector.DagsterCollector) {
 	spawn("code_location_status", collector.CollectCodeLocationStatus)
 	spawn("daemon_health", collector.CollectDaemonHealth)
 	spawn("asset_status", collector.CollectAssetStatus)
+	spawn("op_pool_concurrency", collector.CollectOpPoolConcurrency)
 
 	wg.Wait()
 }


### PR DESCRIPTION
## What

Four new metrics reading Dagster's `instance.concurrencyLimits`, all Gauges labeled `pool`:

- `dagster_op_pool_concurrency_active_slots` — slots currently claimed (steps actively running)
- `dagster_op_pool_concurrency_assigned_steps` — steps assigned a slot but not yet running
- `dagster_op_pool_concurrency_pending_steps` — steps waiting for a slot, not yet assigned one
- `dagster_op_pool_concurrency_limit` (labeled `pool`, `using_default_limit`) — effective concurrency limit per pool

Plus a new collector (`op_pool_concurrency`, its own GraphQL query, wired into `scrape.go`), a dev fixture (`heavy_pool_job`, `heavy_pool_fanout_job` in `dev/dagster_workspace/job.py`, `concurrency.pools.default_limit: 1` in `dagster.yaml`), two new Grafana panels, and docs (`docs/architecture.md`, `docs/metrics.md`, README table/example-output/PromQL/Testing sections).

## Why

Closes #111. `instance.concurrencyLimits` is a genuinely separate mechanism from the existing `dagster_run_queue_concurrency_key_backlog`: that one tracks whole *runs* stuck behind a run-level `dagster/concurrency_key` tag (#41's investigation notes found `instance.concurrencyLimits` wrong for that question); this tracks individual *steps* sharing a named op/step "pool" of slots across the whole instance — exactly the field #41 ruled out for the other purpose. The label is `pool`, not `concurrency_key`, deliberately, so the two don't read as the same thing (an open question the issue itself raised).

No exporter-side zero-fill is needed, unlike the run-queue backlog (#81): `instance.concurrencyLimits` is Dagster's own event-log storage answering "how many slots are claimed against this pool," and it persistently remembers every pool that's ever claimed a slot, reporting it at zero once idle. The collector just replaces its whole map on every scrape — no unbounded map growth to worry about.

## QA

Verified end-to-end against the real dev stack (Dagster 1.13.15, docker compose), and it surfaced two load-bearing facts neither the issue nor the GraphQL schema would have caught:

- **`concurrency.pools.granularity` has to be `"op"`, not `"run"`.** Under `"run"` granularity the pool's limit is still enforced (at run-queue admission), but no per-step slot is ever actually claimed in the tables these metrics read — `active_slots`/`assigned_steps`/`pending_steps` stayed `0` while two runs visibly contended for the same one-slot pool. Only `dagster_op_pool_concurrency_limit` is unaffected either way. Confirmed by launching two runs under each granularity setting and watching the difference live.
- **`pending_steps` needs intra-run contention, not two separate runs.** A whole run blocked in Dagster's run queue never submits a step for execution at all, so it never shows up as pending — it's just a second `QUEUED` run. Getting `pending_steps > 0` needed a second dev-fixture job (`heavy_pool_fanout_job`: two ops behind one pool, `multiprocess_executor(max_concurrent=2)`) so both steps are genuinely submitted and contend within one already-started run.

With that fixture, all three step-state metrics were observed nonzero simultaneously from a single live run:

```
dagster_op_pool_concurrency_active_slots{pool="heavy_pool"} 1
dagster_op_pool_concurrency_assigned_steps{pool="heavy_pool"} 1
dagster_op_pool_concurrency_pending_steps{pool="heavy_pool"} 1
dagster_op_pool_concurrency_limit{pool="heavy_pool",using_default_limit="true"} 1
```

...and settled back to `active_slots`/`assigned_steps`/`pending_steps` = `0` (limit persisting) once the run completed. Confirmed reaching Prometheus (`/api/v1/query`) with the same values, and the two new Grafana panels ("Op Pool Concurrency", "Op Pool Concurrency Limit") rendering real series. Swept every dashboard panel afterward — only the unrelated, not-triggered-this-run "Run Queue Backlog by Concurrency Key" panel came back empty, matching prior baseline behavior.

`go build`/`go vet`/`go test -race`/`golangci-lint run` all clean; `go.mod`/`go.sum` unchanged; dashboard JSON stays `jq`-formatted; `ruff check .` clean.

## Ref

Closes #111